### PR TITLE
Improve wrapper performance

### DIFF
--- a/src/Libraries/RevitServices/Persistence/ElementIDLifecycleManager.cs
+++ b/src/Libraries/RevitServices/Persistence/ElementIDLifecycleManager.cs
@@ -65,20 +65,21 @@ namespace RevitServices.Persistence
         {
 
             List<Object> existingWrappers;
-            if (wrappers.TryGetValue(elementID, out existingWrappers))
-            {
-                //ID already existed, check we're not over adding
-                Validity.Assert(!existingWrappers.Contains(wrapper), 
-                    "Lifecycle manager alert: registering the same Revit Element Wrapper twice"
-                    + " {6528305F}");
-                //return;
-            }
-            else
+            if (!wrappers.TryGetValue(elementID, out existingWrappers))
             {
                 existingWrappers = new List<object>();
                 wrappers.Add(elementID, existingWrappers);
             }
-
+#if DEBUG
+            else
+            {
+                //ID already existed, check we're not over adding
+                Validity.Assert(!existingWrappers.Contains(wrapper),
+                    "Lifecycle manager alert: registering the same Revit Element Wrapper twice"
+                    + " {6528305F}");
+                //return;
+            }
+#endif
             existingWrappers.Add(wrapper);
             if (!revitDeleted.ContainsKey(elementID))
             {


### PR DESCRIPTION
### List of Affected Nodes/Modules

All Revit nodes that create a wrapper element

### Current Performance
Currently every single time an element wrapper is created, an unnecessary assertion is performed to ensure that this wrapper is unique. This assertion is not logged or displayed to the user and from what I can tell, does not benefit them.

### Proposed Performance
The best performance optimization is to avoid doing work :) . If there is no clear benefit to do this assertion every time, I propose we remove it from the release builds and only keep it there for debug builds. The performance benefit is small at face value but would add up over time in a large graph.

### Dynamo Tuneup Comparison
On a model with ~55k elements collecting all elements 10 times improves performance about 8%, from 10.5 seconds to about 9.6 seconds on average.

![xZ3tA45ugV](https://github.com/user-attachments/assets/a95b02b3-7347-47b0-9c28-ee993a283b3b)

![sdMJgX2HG3](https://github.com/user-attachments/assets/6693303d-899a-4e3b-bb28-21a3c4cc3d5c)


### Checklist

- [x] There are no public function signature changes
- [x] Any public code that is no longer in use is tagged as obsolete and preserved.
- [x] The code changes have been documented
- [x] The overall behavior does not change
