### PR TITLE
Dead-End: Improve Family Instance Creation

### DIFF
--- a/src/Libraries/RevitNodes/Elements/FamilyInstance.cs
+++ b/src/Libraries/RevitNodes/Elements/FamilyInstance.cs
@@ -9,6 +9,7 @@ using Revit.GeometryConversion;
 using Revit.GeometryReferences;
 using RevitServices.Persistence;
 using RevitServices.Transactions;
+using DB = Autodesk.Revit.DB;
 using Point = Autodesk.DesignScript.Geometry.Point;
 using Surface = Autodesk.DesignScript.Geometry.Surface;
 using Vector = Autodesk.DesignScript.Geometry.Vector;
@@ -27,7 +28,7 @@ namespace Revit.Elements
         /// Wrap an existing FamilyInstance.
         /// </summary>
         /// <param name="instance"></param>
-        protected FamilyInstance(Autodesk.Revit.DB.FamilyInstance instance)
+        protected FamilyInstance(DB.FamilyInstance instance)
         {
             SafeInit(() => InitFamilyInstance(instance), true);
         }
@@ -35,8 +36,8 @@ namespace Revit.Elements
         /// <summary>
         /// Internal constructor for a FamilyInstance
         /// </summary>
-        internal FamilyInstance(Autodesk.Revit.DB.FamilySymbol fs, Autodesk.Revit.DB.XYZ pos,
-            Autodesk.Revit.DB.Level level)
+        internal FamilyInstance(DB.FamilySymbol fs, DB.XYZ pos,
+            DB.Level level)
         {
             SafeInit(() => InitFamilyInstance(fs, pos, level));
         }
@@ -44,22 +45,22 @@ namespace Revit.Elements
         /// <summary>
         /// Internal constructor for a FamilyInstance
         /// </summary>
-        internal FamilyInstance(Autodesk.Revit.DB.FamilySymbol fs, Autodesk.Revit.DB.XYZ pos)
+        internal FamilyInstance(DB.FamilySymbol fs, DB.XYZ pos)
         {
             SafeInit(() => InitFamilyInstance(fs, pos));
         }
 
-        internal FamilyInstance(Autodesk.Revit.DB.FamilySymbol fs, Autodesk.Revit.DB.Reference reference, Autodesk.Revit.DB.Line pos)
+        internal FamilyInstance(DB.FamilySymbol fs, DB.Reference reference, DB.Line pos)
         {
             SafeInit(() => InitFamilyInstance(fs, reference, pos));
         }
 
-        internal FamilyInstance(Autodesk.Revit.DB.FamilySymbol fs, Autodesk.Revit.DB.Reference reference, Autodesk.Revit.DB.XYZ location, Autodesk.Revit.DB.XYZ referenceDirection)
+        internal FamilyInstance(DB.FamilySymbol fs, DB.Reference reference, DB.XYZ location, DB.XYZ referenceDirection)
         {
             SafeInit(() => InitFamilyInstance(fs, reference, location, referenceDirection));
         }
 
-        internal FamilyInstance(Autodesk.Revit.DB.FamilySymbol fs, Autodesk.Revit.DB.Element host, Autodesk.Revit.DB.XYZ location)
+        internal FamilyInstance(DB.FamilySymbol fs, DB.Element host, DB.XYZ location)
         {
             SafeInit(() => InitFamilyInstance(fs, host, location));
         }
@@ -71,7 +72,7 @@ namespace Revit.Elements
         /// Initialize a FamilyInstance element
         /// </summary>
         /// <param name="instance"></param>
-        private void InitFamilyInstance(Autodesk.Revit.DB.FamilyInstance instance)
+        private void InitFamilyInstance(DB.FamilyInstance instance)
         {
             InternalSetFamilyInstance(instance);
         }
@@ -79,12 +80,12 @@ namespace Revit.Elements
         /// <summary>
         /// Initialize a FamilyInstance element
         /// </summary>
-        private void InitFamilyInstance(Autodesk.Revit.DB.FamilySymbol fs, Autodesk.Revit.DB.XYZ pos,
-            Autodesk.Revit.DB.Level level)
+        private void InitFamilyInstance(DB.FamilySymbol fs, DB.XYZ pos,
+            DB.Level level)
         {
             //Phase 1 - Check to see if the object exists and should be rebound
             var oldFam =
-                ElementBinder.GetElementFromTrace<Autodesk.Revit.DB.FamilyInstance>(Document);
+                ElementBinder.GetElementFromTrace<DB.FamilyInstance>(Document);
 
             //There was a point, rebind to that, and adjust its position
             if (oldFam != null)
@@ -106,23 +107,15 @@ namespace Revit.Elements
             if (EnableBatchProcessing)
             {
                 BatchProcessingId = Guid.NewGuid().ToString();
-                var cd = new FamilyInstanceCreationData(pos, fs, level, Autodesk.Revit.DB.Structure.StructuralType.NonStructural);
+                var cd = new FamilyInstanceCreationData(pos, fs, level, NonStructural);
                 TransactionManager.Instance.AddCreationData(BatchProcessingId, cd);
                 TransactionManager.Instance.TransactionWrapper.TransactionCommitted += ResolveInternalElement;
             }
             else
             {
-                Autodesk.Revit.DB.FamilyInstance fi;
-                if (Document.IsFamilyDocument)
-                {
-                    fi = Document.FamilyCreate.NewFamilyInstance(pos, fs, level,
-                        Autodesk.Revit.DB.Structure.StructuralType.NonStructural);
-                }
-                else
-                {
-                    fi = Document.Create.NewFamilyInstance(
-                        pos, fs, level, Autodesk.Revit.DB.Structure.StructuralType.NonStructural);
-                }
+                var fi = Document.IsFamilyDocument
+                    ? Document.FamilyCreate.NewFamilyInstance(pos, fs, level, NonStructural)
+                    : Document.Create.NewFamilyInstance(pos, fs, level, NonStructural);
 
                 InternalSetFamilyInstance(fi);
 
@@ -159,14 +152,16 @@ namespace Revit.Elements
             TransactionManager.Instance.TransactionWrapper.TransactionCommitted -= ResolveInternalElement;
         }
 
+        const DB.Structure.StructuralType NonStructural = DB.Structure.StructuralType.NonStructural;
+
         /// <summary>
         /// Initialize a FamilyInstance element
         /// </summary>
-        private void InitFamilyInstance(Autodesk.Revit.DB.FamilySymbol fs, Autodesk.Revit.DB.XYZ pos)
+        private void InitFamilyInstance(DB.FamilySymbol fs, DB.XYZ pos)
         {
             //Phase 1 - Check to see if the object exists and should be rebound
             var oldFam =
-                ElementBinder.GetElementFromTrace<Autodesk.Revit.DB.FamilyInstance>(Document);
+                ElementBinder.GetElementFromTrace<DB.FamilyInstance>(Document);
 
             //There was a point, rebind to that, and adjust its position
             if (oldFam != null)
@@ -184,22 +179,32 @@ namespace Revit.Elements
             if (!fs.IsActive)
                 fs.Activate();
 
-            var fi = Document.IsFamilyDocument
-                ? Document.FamilyCreate.NewFamilyInstance(pos, fs, Autodesk.Revit.DB.Structure.StructuralType.NonStructural)
-                : Document.Create.NewFamilyInstance(pos, fs, Autodesk.Revit.DB.Structure.StructuralType.NonStructural);
+            if (EnableBatchProcessing)
+            {
+                BatchProcessingId = Guid.NewGuid().ToString();
+                var cd = new FamilyInstanceCreationData(pos, fs, NonStructural);
+                TransactionManager.Instance.AddCreationData(BatchProcessingId, cd);
+                TransactionManager.Instance.TransactionWrapper.TransactionCommitted += ResolveInternalElement;
+            }
+            else
+            {
+                var fi = Document.IsFamilyDocument
+                    ? Document.FamilyCreate.NewFamilyInstance(pos, fs, NonStructural)
+                    : Document.Create.NewFamilyInstance(pos, fs, NonStructural);
 
-            InternalSetFamilyInstance(fi);
+                InternalSetFamilyInstance(fi);
+
+                ElementBinder.SetElementForTrace(InternalElement);
+            }
 
             TransactionManager.Instance.TransactionTaskDone();
-
-            ElementBinder.SetElementForTrace(InternalElement);
         }
 
-        private void InitFamilyInstance(Autodesk.Revit.DB.FamilySymbol fs, Autodesk.Revit.DB.Reference reference, Autodesk.Revit.DB.Line pos)
+        private void InitFamilyInstance(DB.FamilySymbol fs, DB.Reference reference, DB.Line pos)
         {
             //Phase 1 - Check to see if the object exists and should be rebound
             var oldFam =
-                ElementBinder.GetElementFromTrace<Autodesk.Revit.DB.FamilyInstance>(Document);
+                ElementBinder.GetElementFromTrace<DB.FamilyInstance>(Document);
 
             //There was an existing family instance, rebind to that, and adjust its position
             if (oldFam != null && oldFam.HostFace.ElementId == reference.ElementId)
@@ -217,23 +222,34 @@ namespace Revit.Elements
             if (!fs.IsActive)
                 fs.Activate();
 
-            var fi = Document.IsFamilyDocument
-                ? Document.FamilyCreate.NewFamilyInstance(reference, pos, fs)
-                : Document.Create.NewFamilyInstance(reference, pos, fs);
+            if (EnableBatchProcessing)
+            {
+                BatchProcessingId = Guid.NewGuid().ToString();
+                var face = ElementFaceReference.TryGetFaceFromReference(Document, reference);
+                var cd = new FamilyInstanceCreationData(face, pos, fs);
+                TransactionManager.Instance.AddCreationData(BatchProcessingId, cd);
+                TransactionManager.Instance.TransactionWrapper.TransactionCommitted += ResolveInternalElement;
+            }
+            else
+            {
+                var fi = Document.IsFamilyDocument
+                    ? Document.FamilyCreate.NewFamilyInstance(reference, pos, fs)
+                    : Document.Create.NewFamilyInstance(reference, pos, fs);
 
-            InternalSetFamilyInstance(fi);
+                InternalSetFamilyInstance(fi);
+
+                ElementBinder.SetElementForTrace(InternalElement);
+            }
 
             TransactionManager.Instance.TransactionTaskDone();
-
-            ElementBinder.SetElementForTrace(InternalElement);
         }
 
-        private void InitFamilyInstance(Autodesk.Revit.DB.FamilySymbol fs, Autodesk.Revit.DB.Reference reference, Autodesk.Revit.DB.XYZ location,
-            Autodesk.Revit.DB.XYZ referenceDirection)
+        private void InitFamilyInstance(DB.FamilySymbol fs, DB.Reference reference, DB.XYZ location,
+            DB.XYZ referenceDirection)
         {
             //Phase 1 - Check to see if the object exists and should be rebound
             var oldFam =
-                ElementBinder.GetElementFromTrace<Autodesk.Revit.DB.FamilyInstance>(Document);
+                ElementBinder.GetElementFromTrace<DB.FamilyInstance>(Document);
 
             //There was an existing family instance, rebind to that, and adjust its position
             if (oldFam != null && oldFam.HostFace.ElementId == reference.ElementId)
@@ -250,23 +266,33 @@ namespace Revit.Elements
             //If the symbol is not active, then activate it
             if (!fs.IsActive)
                 fs.Activate();
+            if (EnableBatchProcessing)
+            {
+                BatchProcessingId = Guid.NewGuid().ToString();
+                var face = ElementFaceReference.TryGetFaceFromReference(Document, reference);
+                var cd = new FamilyInstanceCreationData(face, location, referenceDirection, fs);
+                TransactionManager.Instance.AddCreationData(BatchProcessingId, cd);
+                TransactionManager.Instance.TransactionWrapper.TransactionCommitted += ResolveInternalElement;
+            }
+            else
+            {
+                var fi = Document.IsFamilyDocument
+                    ? Document.FamilyCreate.NewFamilyInstance(reference, location, referenceDirection, fs)
+                    : Document.Create.NewFamilyInstance(reference, location, referenceDirection, fs);
 
-            var fi = Document.IsFamilyDocument
-                ? Document.FamilyCreate.NewFamilyInstance(reference, location, referenceDirection, fs)
-                : Document.Create.NewFamilyInstance(reference, location, referenceDirection, fs);
+                InternalSetFamilyInstance(fi);
 
-            InternalSetFamilyInstance(fi);
+                ElementBinder.SetElementForTrace(InternalElement);
+            }
 
             TransactionManager.Instance.TransactionTaskDone();
-
-            ElementBinder.SetElementForTrace(InternalElement);
         }
 
-        private void InitFamilyInstance(Autodesk.Revit.DB.FamilySymbol fs, Autodesk.Revit.DB.Element host, Autodesk.Revit.DB.XYZ location)
+        private void InitFamilyInstance(DB.FamilySymbol fs, DB.Element host, DB.XYZ location)
         {
             //Phase 1 - Check to see if the object exists and should be rebound
             var oldFam =
-                ElementBinder.GetElementFromTrace<Autodesk.Revit.DB.FamilyInstance>(Document);
+                ElementBinder.GetElementFromTrace<DB.FamilyInstance>(Document);
 
             //There was an existing family instance, rebind to that, and adjust its position
             if (oldFam != null && oldFam.Host.Id == host.Id)
@@ -283,22 +309,33 @@ namespace Revit.Elements
             //If the symbol is not active, then activate it
             if (!fs.IsActive)
                 fs.Activate();
-            var level = Document.GetElement(host.LevelId) as Autodesk.Revit.DB.Level;
-            var fi = Document.IsFamilyDocument
-                ? Document.FamilyCreate.NewFamilyInstance(location, fs, host, Autodesk.Revit.DB.Structure.StructuralType.NonStructural)
-                : Document.Create.NewFamilyInstance(location, fs, host, level, Autodesk.Revit.DB.Structure.StructuralType.NonStructural);
 
-            InternalSetFamilyInstance(fi);
+            var level = Document.GetElement(host.LevelId) as DB.Level;
+            if (EnableBatchProcessing)
+            {
+                BatchProcessingId = Guid.NewGuid().ToString();
+                var cd = new FamilyInstanceCreationData(location, fs, host, level, NonStructural);
+                TransactionManager.Instance.AddCreationData(BatchProcessingId, cd);
+                TransactionManager.Instance.TransactionWrapper.TransactionCommitted += ResolveInternalElement;
+            }
+            else
+            {
+                var fi = Document.IsFamilyDocument
+                    ? Document.FamilyCreate.NewFamilyInstance(location, fs, host, NonStructural)
+                    : Document.Create.NewFamilyInstance(location, fs, host, level, NonStructural);
+
+                InternalSetFamilyInstance(fi);
+
+                ElementBinder.SetElementForTrace(InternalElement);
+            }
 
             TransactionManager.Instance.TransactionTaskDone();
-
-            ElementBinder.SetElementForTrace(InternalElement);
         }
         #endregion
 
         #region Private mutators
 
-        private void InternalSetLevel(Autodesk.Revit.DB.Level level)
+        private void InternalSetLevel(DB.Level level)
         {
             if (InternalFamilyInstance.LevelId.Compare(level.Id) == 0)
                 return;
@@ -306,26 +343,26 @@ namespace Revit.Elements
             TransactionManager.Instance.EnsureInTransaction(Document);
 
             // http://thebuildingcoder.typepad.com/blog/2011/01/family-instance-missing-level-property.html
-            InternalFamilyInstance.get_Parameter(Autodesk.Revit.DB.BuiltInParameter.FAMILY_LEVEL_PARAM).Set(level.Id);
+            InternalFamilyInstance.get_Parameter(DB.BuiltInParameter.FAMILY_LEVEL_PARAM).Set(level.Id);
 
             TransactionManager.Instance.TransactionTaskDone();
         }
 
-        private void InternalSetPosition(Autodesk.Revit.DB.XYZ fi)
+        private void InternalSetPosition(DB.XYZ fi)
         {
             TransactionManager.Instance.EnsureInTransaction(Document);
 
-            var lp = InternalFamilyInstance.Location as Autodesk.Revit.DB.LocationPoint;
+            var lp = InternalFamilyInstance.Location as DB.LocationPoint;
             if (lp != null && !lp.Point.IsAlmostEqualTo(fi)) lp.Point = fi;
 
             TransactionManager.Instance.TransactionTaskDone();
         }
 
-        private void InternalSetPosition(Autodesk.Revit.DB.Curve pos)
+        private void InternalSetPosition(DB.Curve pos)
         {
             TransactionManager.Instance.EnsureInTransaction(Document);
 
-            var lp = InternalFamilyInstance.Location as Autodesk.Revit.DB.LocationCurve;
+            var lp = InternalFamilyInstance.Location as DB.LocationCurve;
 
             if (lp != null && lp.Curve != pos) lp.Curve = pos;
 
@@ -452,7 +489,7 @@ namespace Revit.Elements
             }
             var reference = ElementFaceReference.TryGetFaceReference(face);
 
-            return new FamilyInstance(familyType.InternalFamilySymbol, reference.InternalReference, (Autodesk.Revit.DB.Line)line.ToRevitType());
+            return new FamilyInstance(familyType.InternalFamilySymbol, reference.InternalReference, (DB.Line)line.ToRevitType());
         }
 
         /// <summary>
@@ -544,7 +581,7 @@ namespace Revit.Elements
             }
 
             return DocumentManager.Instance
-                .ElementsOfType<Autodesk.Revit.DB.FamilyInstance>()
+                .ElementsOfType<DB.FamilyInstance>()
                 .Where(x => x.Symbol.Id == familyType.InternalFamilySymbol.Id)
                 .Select(x => FromExisting(x, true))
                 .ToArray();
@@ -558,7 +595,7 @@ namespace Revit.Elements
         /// <returns>New family instance.</returns>
         public static FamilyInstance ByCoordinateSystem(FamilyType familyType, CoordinateSystem coordinateSystem)
         {
-            var transform = coordinateSystem.ToTransform() as Autodesk.Revit.DB.Transform;
+            var transform = coordinateSystem.ToTransform() as DB.Transform;
             double[] newRotationAngles;
             TransformUtils.ExtractEularAnglesFromTransform(transform, out newRotationAngles);
             double rotation = ConvertEularToAngleDegrees(newRotationAngles.FirstOrDefault());
@@ -596,7 +633,7 @@ namespace Revit.Elements
         /// <param name="familyInstance"></param>
         /// <param name="isRevitOwned"></param>
         /// <returns></returns>
-        internal static FamilyInstance FromExisting(Autodesk.Revit.DB.FamilyInstance familyInstance, bool isRevitOwned)
+        internal static FamilyInstance FromExisting(DB.FamilyInstance familyInstance, bool isRevitOwned)
         {
             return new FamilyInstance(familyInstance)
             {
@@ -674,8 +711,8 @@ namespace Revit.Elements
             if (!oldRotationAngles[0].AlmostEquals(newRotationAngle, 1.0e-6))
             {
                 var rotateAngle = newRotationAngle - oldRotationAngles[0];
-                var axis = Autodesk.Revit.DB.Line.CreateUnbound(oldTransform.Origin, oldTransform.BasisZ);
-                Autodesk.Revit.DB.ElementTransformUtils.RotateElement(Document, new Autodesk.Revit.DB.ElementId(Id), axis, -rotateAngle);
+                var axis = DB.Line.CreateUnbound(oldTransform.Origin, oldTransform.BasisZ);
+                DB.ElementTransformUtils.RotateElement(Document, new DB.ElementId(Id), axis, -rotateAngle);
             }
 
             TransactionManager.Instance.TransactionTaskDone();
@@ -726,7 +763,7 @@ namespace Revit.Elements
         /// Get the transform of the internal family instance
         /// </summary>
         /// <returns>The internal transform</returns>
-        private Autodesk.Revit.DB.Transform InternalGetTransform()
+        private DB.Transform InternalGetTransform()
         {
             TransactionManager.Instance.EnsureInTransaction(Document);
 
@@ -738,9 +775,9 @@ namespace Revit.Elements
         private double GetRotationFromCS(CoordinateSystem fromCS, CoordinateSystem contextCS)
         {
             var elementTransform = this.InternalFamilyInstance.GetTransform();
-            var newTransform = contextCS.ToTransform() as Autodesk.Revit.DB.Transform;
+            var newTransform = contextCS.ToTransform() as DB.Transform;
 
-            var oldTransform = fromCS.ToTransform() as Autodesk.Revit.DB.Transform;
+            var oldTransform = fromCS.ToTransform() as DB.Transform;
 
             double[] oldRotationAngles;
             TransformUtils.ExtractEularAnglesFromTransform(oldTransform, out oldRotationAngles);
@@ -757,9 +794,9 @@ namespace Revit.Elements
         private void SetLocationFromCS(CoordinateSystem fromCS, CoordinateSystem contextCS)
         {
             var locationGeometry = this.InternalElement.Location;
-            if (locationGeometry is Autodesk.Revit.DB.LocationCurve)
+            if (locationGeometry is DB.LocationCurve)
             {
-                var locationCurve = locationGeometry as Autodesk.Revit.DB.LocationCurve;
+                var locationCurve = locationGeometry as DB.LocationCurve;
                 var dynamoCurve = locationCurve.Curve.ToProtoType();
                 var newLocation = dynamoCurve.Transform(fromCS, contextCS) as Curve;
                 locationCurve.Curve = newLocation.ToRevitType(true);
@@ -767,9 +804,9 @@ namespace Revit.Elements
                 newLocation.Dispose();
                 return;
             }
-            else if (locationGeometry is Autodesk.Revit.DB.LocationPoint)
+            else if (locationGeometry is DB.LocationPoint)
             {
-                var location = this.InternalElement.Location as Autodesk.Revit.DB.LocationPoint;
+                var location = this.InternalElement.Location as DB.LocationPoint;
                 var dynamoPoint = location.Point.ToPoint(true);
                 var newLocation = dynamoPoint.Transform(fromCS, contextCS) as Autodesk.DesignScript.Geometry.Point;
                 location.Point = newLocation.ToRevitType(true);

--- a/src/Libraries/RevitNodes/GeometryReferences/ElementFaceReference.cs
+++ b/src/Libraries/RevitNodes/GeometryReferences/ElementFaceReference.cs
@@ -30,9 +30,9 @@ namespace Revit.GeometryReferences
             return new ElementFaceReference(arg);
         }
 
-        internal static Autodesk.DesignScript.Geometry.Surface AddTag( Autodesk.DesignScript.Geometry.Surface surface, Autodesk.Revit.DB.Reference reference )
+        internal static Autodesk.DesignScript.Geometry.Surface AddTag(Autodesk.DesignScript.Geometry.Surface surface, Autodesk.Revit.DB.Reference reference)
         {
-            surface.Tags.AddTag( DefaultTag, reference );
+            surface.Tags.AddTag(DefaultTag, reference);
             return surface;
         }
 
@@ -40,7 +40,7 @@ namespace Revit.GeometryReferences
 
         internal static ElementFaceReference TryGetFaceReference(object geometryObject, string nodeTypeString = "This node")
         {
-            var geometry = (dynamic) geometryObject;
+            var geometry = (dynamic)geometryObject;
 
             try
             {
@@ -96,6 +96,23 @@ namespace Revit.GeometryReferences
         public static ElementFaceReference BySurface(Autodesk.DesignScript.Geometry.Surface surface)
         {
             return TryGetFaceReference(surface);
+        }
+
+        public static Face TryGetFaceFromReference(Document doc, Reference reference)
+        {
+            if (reference.ElementReferenceType != ElementReferenceType.REFERENCE_TYPE_SURFACE)
+            {
+                return null;
+            }
+
+            Element e = null;
+            try
+            {
+                e = doc.GetElement(reference.ElementId);
+            }
+            catch { }
+
+            return e?.GetGeometryObjectFromReference(reference) as Face;
         }
     }
 


### PR DESCRIPTION
Using the batch methods did not yield better performance in Revit 2025. My guess is that at some point in the recent releases the instance generation performance was greatly increased and the batch methods are no longer wielding any practical benefits. Furthermore, this makes using the family instances as inputs down the chain of nodes impossible or very impractical. 

<details>
  <summary>superseded details</summary>
  
### List of Affected Nodes/Modules
FamilyInstance.ByPoint
FamilyInstance.ByPointAndLevel
FamilyInstance.ByCoordinates
FamilyInstance.ByCoordinateSystem
FamilyInstance.ByFace
FamilyInstance.ByFace2
FamilyInstance.ByHostAndPoint


### Current Performance
Revit provides batch family instance creation methods. However using them directly would require the introduction of new nodes or changing the existing nodes' method signature.

### Proposed Performance
We can collect all of the family instance creations and schedule them to run in a single batch call at the end of the transaction.


### Dynamo Tuneup Comparison
We have CPU time and then we have Revit time. TuneUp and profiling in VS can't show the whole picture, because it doesn't capture the Revit regeneration time. Creating 30k instances and returning control to the user takes a lot longer than what is reported.


### Checklist

- [x] There are no public function signature changes
- [ ] Any public code that is no longer in use is tagged as obsolete and preserved.
- [x] The code changes have been documented
- [ ] The overall behavior does not change

</details>
