### PR TITLE
Inlining Element Wrapping

### DIFF
--- a/src/Libraries/RevitNodes/Elements/FamilyInstance.cs
+++ b/src/Libraries/RevitNodes/Elements/FamilyInstance.cs
@@ -181,8 +181,8 @@ namespace Revit.Elements
             if (!fs.IsActive)
                 fs.Activate();
 
-            var fi = Document.IsFamilyDocument 
-                ? Document.FamilyCreate.NewFamilyInstance(reference, pos, fs) 
+            var fi = Document.IsFamilyDocument
+                ? Document.FamilyCreate.NewFamilyInstance(reference, pos, fs)
                 : Document.Create.NewFamilyInstance(reference, pos, fs);
 
             InternalSetFamilyInstance(fi);
@@ -215,8 +215,8 @@ namespace Revit.Elements
             if (!fs.IsActive)
                 fs.Activate();
 
-            var fi = Document.IsFamilyDocument 
-                ? Document.FamilyCreate.NewFamilyInstance(reference,  location, referenceDirection, fs) 
+            var fi = Document.IsFamilyDocument
+                ? Document.FamilyCreate.NewFamilyInstance(reference, location, referenceDirection, fs)
                 : Document.Create.NewFamilyInstance(reference, location, referenceDirection, fs);
 
             InternalSetFamilyInstance(fi);
@@ -329,7 +329,7 @@ namespace Revit.Elements
         {
             get
             {
-                return InternalFamilyInstance.IsValidObject ? 
+                return InternalFamilyInstance.IsValidObject ?
                     InternalFamilyInstance.FacingOrientation.ToVector() : null;
             }
         }
@@ -377,8 +377,8 @@ namespace Revit.Elements
             if (familyType == null)
             {
                 throw new ArgumentNullException("familyType");
-            } 
-            
+            }
+
             if (point == null)
             {
                 throw new ArgumentNullException("point");
@@ -413,7 +413,7 @@ namespace Revit.Elements
             }
             var reference = ElementFaceReference.TryGetFaceReference(face);
 
-            return new FamilyInstance(familyType.InternalFamilySymbol, reference.InternalReference, (Autodesk.Revit.DB.Line) line.ToRevitType());
+            return new FamilyInstance(familyType.InternalFamilySymbol, reference.InternalReference, (Autodesk.Revit.DB.Line)line.ToRevitType());
         }
 
         /// <summary>
@@ -427,7 +427,7 @@ namespace Revit.Elements
         /// <param name="location">Point on the face where the instance is to be placed</param>
         /// <param name="referenceDirection">A vector that defines the direction of placement of the family instance</param>
         /// <returns>FamilyInstance</returns>
-        public static FamilyInstance ByFace(FamilyType familyType, Surface face, Point location, 
+        public static FamilyInstance ByFace(FamilyType familyType, Surface face, Point location,
             Vector referenceDirection)
         {
             if (familyType == null)
@@ -448,7 +448,7 @@ namespace Revit.Elements
             }
             var reference = ElementFaceReference.TryGetFaceReference(face);
 
-            return new FamilyInstance(familyType.InternalFamilySymbol, reference.InternalReference, 
+            return new FamilyInstance(familyType.InternalFamilySymbol, reference.InternalReference,
                 location.ToXyz(), referenceDirection.ToXyz());
         }
 
@@ -585,7 +585,7 @@ namespace Revit.Elements
 
                     // TODO: This might need to change since its not clear if the Host element is revit owned or not.
                     // Currently there is no way of figuring this out, therefore the assumption is true (Revit owned)
-                    return ElementWrapper.Wrap(this.InternalFamilyInstance.Host, true);
+                    return this.InternalFamilyInstance.Host.ToDSType(true);
 
                 throw new Exception(Properties.Resources.InvalidHost);
             }
@@ -594,10 +594,10 @@ namespace Revit.Elements
         /// <summary>
         /// Gets the family of this family instance
         /// </summary>
-        public Family GetFamily 
-        { 
-            get 
-            { 
+        public Family GetFamily
+        {
+            get
+            {
                 return Family.FromExisting(this.InternalFamilyInstance.Symbol.Family, true);
             }
         }
@@ -613,7 +613,7 @@ namespace Revit.Elements
             get { return base.Type; }
         }
 
-        
+
 
         /// <summary>
         /// Set the Euler angle of the family instance around its local Z-axis.

--- a/src/Libraries/RevitNodes/Elements/InternalUtilities/ElementWrapper.cs
+++ b/src/Libraries/RevitNodes/Elements/InternalUtilities/ElementWrapper.cs
@@ -1,7 +1,7 @@
 ﻿using Autodesk.DesignScript.Runtime;
 using Autodesk.Revit.DB;
 using Revit.Elements.Views;
-using View3D = Revit.Elements.Views.View3D;
+using DB = Autodesk.Revit.DB;
 
 namespace Revit.Elements
 {
@@ -18,399 +18,271 @@ namespace Revit.Elements
         /// <param name="ele"></param>
         /// <param name="isRevitOwned">Whether the returned object should be revit owned or not</param>
         /// <returns></returns>
-        public static Element ToDSType(this Autodesk.Revit.DB.Element ele, bool isRevitOwned)
+        public static Element ToDSType(this DB.Element ele, bool isRevitOwned)
         {
             // cast to dynamic to dispatch to the appropriate wrapping method
-            dynamic dynamicElement = ele;
-            return ElementWrapper.Wrap(dynamicElement, isRevitOwned);
+            //dynamic dynamicElement = ele;
+            //return ElementWrapper.Wrap(dynamicElement, isRevitOwned);
 
-        }
-
-        #region Wrap methods
-
-        public static UnknownElement Wrap(Autodesk.Revit.DB.Element element, bool isRevitOwned)
-        {
-            return UnknownElement.FromExisting(element, isRevitOwned);
-        }
-
-        public static AbstractFamilyInstance Wrap(Autodesk.Revit.DB.FamilyInstance ele, bool isRevitOwned)
-        {
-            if (AdaptiveComponentInstanceUtils.HasAdaptiveFamilySymbol(ele))
+            switch (ele)
             {
-                return AdaptiveComponent.FromExisting(ele, isRevitOwned);
-            }
+                case DB.Panel panel:
+                    {
+                        if (AdaptiveComponentInstanceUtils.IsAdaptiveFamilySymbol(panel.Symbol))
+                        {
+                            return AdaptiveComponent.FromExisting(panel, isRevitOwned);
+                        }
 
-            if (ele.StructuralType != Autodesk.Revit.DB.Structure.StructuralType.NonStructural &&
-                ele.StructuralType != Autodesk.Revit.DB.Structure.StructuralType.Footing)
-            {
-                return StructuralFraming.FromExisting(ele, isRevitOwned);
-            }
+                        return CurtainPanel.FromExisting(panel, isRevitOwned);
+                    }
 
-            return FamilyInstance.FromExisting(ele, isRevitOwned);
-        }
+                case DB.Mullion mul:
+                    return Mullion.FromExisting(mul, isRevitOwned);
 
-        public static Area Wrap(Autodesk.Revit.DB.Area ele, bool isRevitOwned)
-        {
-            return Area.FromExisting(ele, isRevitOwned);
-        }
+                case DB.FamilyInstance fi:
+                    {
+                        if (AdaptiveComponentInstanceUtils.HasAdaptiveFamilySymbol(fi))
+                        {
+                            return AdaptiveComponent.FromExisting(fi, isRevitOwned);
+                        }
 
-        public static Ceiling Wrap(Autodesk.Revit.DB.Ceiling ele, bool isRevitOwned)
-        {
-            return Ceiling.FromExisting(ele, isRevitOwned);
-        }
+                        if (fi.StructuralType != DB.Structure.StructuralType.NonStructural &&
+                            fi.StructuralType != DB.Structure.StructuralType.Footing)
+                        {
+                            return StructuralFraming.FromExisting(fi, isRevitOwned);
+                        }
 
-        public static CeilingType Wrap(Autodesk.Revit.DB.CeilingType ele, bool isRevitOwned)
-        {
-            return CeilingType.FromExisting(ele, isRevitOwned);
-        }
+                        return FamilyInstance.FromExisting(fi, isRevitOwned);
+                    }
 
-        public static DirectShape Wrap(Autodesk.Revit.DB.DirectShape ele, bool isRevitOwned)
-        {
-            return DirectShape.FromExisting(ele, isRevitOwned);
-        }
+                case DB.Area ar:
+                    return Area.FromExisting(ar, isRevitOwned);
 
-        public static DividedPath Wrap(Autodesk.Revit.DB.DividedPath ele, bool isRevitOwned)
-        {
-            return DividedPath.FromExisting(ele, isRevitOwned);
-        }
+                case DB.Ceiling ce:
+                    return Ceiling.FromExisting(ce, isRevitOwned);
 
-        public static ElementType Wrap(Autodesk.Revit.DB.ElementType elementType, bool isRevitOwned)
-        {
-            return ElementType.FromExisting(elementType, isRevitOwned);
-        }
+                case DB.CeilingType cet:
+                    return CeilingType.FromExisting(cet, isRevitOwned);
 
-        public static DividedSurface Wrap(Autodesk.Revit.DB.DividedSurface ele, bool isRevitOwned)
-        {
-            return DividedSurface.FromExisting(ele, isRevitOwned);
-        }
+                case DB.DirectShape ds:
+                    return DirectShape.FromExisting(ds, isRevitOwned);
 
-        public static Family Wrap(Autodesk.Revit.DB.Family ele, bool isRevitOwned)
-        {
-            return Family.FromExisting(ele, isRevitOwned);
-        }
+                case DB.DividedPath dp:
+                    return DividedPath.FromExisting(dp, isRevitOwned);
 
-        public static FamilyType Wrap(Autodesk.Revit.DB.FamilySymbol ele, bool isRevitOwned)
-        {
-            return FamilyType.FromExisting(ele, isRevitOwned);
-        }
+                case DB.FamilySymbol famType:
+                    return FamilyType.FromExisting(famType, isRevitOwned);
 
-        public static Floor Wrap(Autodesk.Revit.DB.Floor ele, bool isRevitOwned)
-        {
-            return Floor.FromExisting(ele, isRevitOwned);
-        }
+                case DB.FloorType flrType:
+                    return FloorType.FromExisting(flrType, isRevitOwned);
 
-        public static FloorType Wrap(Autodesk.Revit.DB.FloorType ele, bool isRevitOwned)
-        {
-            return FloorType.FromExisting(ele, isRevitOwned);
-        }
+                case DB.ModelTextType mTxtType:
+                    return ModelTextType.FromExisting(mTxtType, isRevitOwned);
 
-        public static Form Wrap(Autodesk.Revit.DB.Form ele, bool isRevitOwned)
-        {
-            return Form.FromExisting(ele, isRevitOwned);
-        }
+                case DB.WallType walType:
+                    return WallType.FromExisting(walType, isRevitOwned);
 
-        [SupressImportIntoVM]
-        public static FreeForm Wrap(Autodesk.Revit.DB.FreeFormElement ele, bool isRevitOwned)
-        {
-            return FreeForm.FromExisting(ele, isRevitOwned);
-        }
+                case DB.ToposolidType toposolidType:
+                    return ToposolidType.FromExisting(toposolidType, isRevitOwned);
 
-        public static Grid Wrap(Autodesk.Revit.DB.Grid ele, bool isRevitOwned)
-        {
-            return Grid.FromExisting(ele, isRevitOwned);
-        }
+                case DB.TextNoteType txtType:
+                    return TextNoteType.FromExisting(txtType, isRevitOwned);
 
-        public static Group Wrap(Autodesk.Revit.DB.Group ele, bool isRevitOwned)
-        {
-            return Group.FromExisting(ele, isRevitOwned);
-        }
+                case DB.FilledRegionType fillRegType:
+                    return FilledRegionType.FromExisting(fillRegType, isRevitOwned);
 
-        public static Level Wrap(Autodesk.Revit.DB.Level ele, bool isRevitOwned)
-        {
-            return Level.FromExisting(ele, isRevitOwned);
-        }
+                case DB.DimensionType dimType:
+                    return DimensionType.FromExisting(dimType, isRevitOwned);
 
-        public static ModelCurve Wrap(Autodesk.Revit.DB.ModelCurve ele, bool isRevitOwned)
-        {
-            return ModelCurve.FromExisting(ele, isRevitOwned);
-        }
+                case DB.RoofType roofType:
+                    return RoofType.FromExisting(roofType, isRevitOwned);
 
-        public static CurveByPoints Wrap(Autodesk.Revit.DB.CurveByPoints ele, bool isRevitOwned)
-        {
-            return CurveByPoints.FromExisting(ele, isRevitOwned);
-        }
+                /* put element types subclasses above this line */
+                case DB.ElementType elType:
+                    return ElementType.FromExisting(elType, isRevitOwned);
 
-        public static ModelText Wrap(Autodesk.Revit.DB.ModelText ele, bool isRevitOwned)
-        {
-            return ModelText.FromExisting(ele, isRevitOwned);
-        }
+                case DB.DividedSurface div:
+                    return DividedSurface.FromExisting(div, isRevitOwned);
 
-        public static ModelTextType Wrap(Autodesk.Revit.DB.ModelTextType ele, bool isRevitOwned)
-        {
-            return ModelTextType.FromExisting(ele, isRevitOwned);
-        }
+                case DB.Family fam:
+                    return Family.FromExisting(fam, isRevitOwned);
 
-        public static ReferencePlane Wrap(Autodesk.Revit.DB.ReferencePlane ele, bool isRevitOwned)
-        {
-            return ReferencePlane.FromExisting(ele, isRevitOwned);
-        }
+                case DB.Floor flr:
+                    return Floor.FromExisting(flr, isRevitOwned);
 
-        public static ReferencePoint Wrap(Autodesk.Revit.DB.ReferencePoint ele, bool isRevitOwned)
-        {
-            return ReferencePoint.FromExisting(ele, isRevitOwned);
-        }
+                case DB.Form frm:
+                    return Form.FromExisting(frm, isRevitOwned);
 
-        public static SketchPlane Wrap(Autodesk.Revit.DB.SketchPlane ele, bool isRevitOwned)
-        {
-            return SketchPlane.FromExisting(ele, isRevitOwned);
-        }
+                case DB.FreeFormElement free:
+                    return FreeForm.FromExisting(free, isRevitOwned);
 
-        public static Wall Wrap(Autodesk.Revit.DB.Wall ele, bool isRevitOwned)
-        {
-            return Wall.FromExisting(ele, isRevitOwned);
-        }
+                case DB.Grid grd:
+                    return Grid.FromExisting(grd, isRevitOwned);
 
-        public static WallType Wrap(Autodesk.Revit.DB.WallType ele, bool isRevitOwned)
-        {
-            return WallType.FromExisting(ele, isRevitOwned);
-        }
+                case DB.Group grp:
+                    return Group.FromExisting(grp, isRevitOwned);
 
-        public static View3D Wrap(Autodesk.Revit.DB.View3D view, bool isRevitOwned)
-        {
-            if (!view.IsTemplate)
-            {
-                if (view.IsPerspective)
-                    return PerspectiveView.FromExisting(view, isRevitOwned);
-                else
-                    return AxonometricView.FromExisting(view, isRevitOwned);
-            }
-            else if (view.IsTemplate)
-            {
-                return View3DTemplate.FromExisting(view, isRevitOwned);
-            }
-            return null;
-        }
+                case DB.Level lvl:
+                    return Level.FromExisting(lvl, isRevitOwned);
 
-        public static Element Wrap(Autodesk.Revit.DB.ViewPlan view, bool isRevitOwned)
-        {
-            switch (view.ViewType)
-            {
-                case ViewType.CeilingPlan:
-                    return CeilingPlanView.FromExisting(view, isRevitOwned);
-                case ViewType.FloorPlan:
-                    return FloorPlanView.FromExisting(view, isRevitOwned);
-                case ViewType.EngineeringPlan:
-                    return StructuralPlanView.FromExisting(view, isRevitOwned);
-                case ViewType.AreaPlan:
-                    return AreaPlanView.FromExisting(view, isRevitOwned);
+                case DB.ModelCurve mCrv:
+                    return ModelCurve.FromExisting(mCrv, isRevitOwned);
+
+                case DB.CurveByPoints cPts:
+                    return CurveByPoints.FromExisting(cPts, isRevitOwned);
+
+                case DB.ModelText mTxt:
+                    return ModelText.FromExisting(mTxt, isRevitOwned);
+
+                case DB.ReferencePlane rPlane:
+                    return ReferencePlane.FromExisting(rPlane, isRevitOwned);
+
+                case DB.ReferencePoint rPt:
+                    return ReferencePoint.FromExisting(rPt, isRevitOwned);
+
+                case DB.SketchPlane skPlane:
+                    return SketchPlane.FromExisting(skPlane, isRevitOwned);
+
+                case DB.Wall wall:
+                    return Wall.FromExisting(wall, isRevitOwned);
+
+                case DB.View3D view3d:
+                    {
+                        if (!view3d.IsTemplate)
+                        {
+                            if (view3d.IsPerspective)
+                                return PerspectiveView.FromExisting(view3d, isRevitOwned);
+                            else
+                                return AxonometricView.FromExisting(view3d, isRevitOwned);
+                        }
+                        else if (view3d.IsTemplate)
+                        {
+                            return View3DTemplate.FromExisting(view3d, isRevitOwned);
+                        }
+                        return null;
+                    }
+
+                case DB.ViewPlan viewPlan:
+                    {
+                        switch (viewPlan.ViewType)
+                        {
+                            case ViewType.CeilingPlan:
+                                return CeilingPlanView.FromExisting(viewPlan, isRevitOwned);
+                            case ViewType.FloorPlan:
+                                return FloorPlanView.FromExisting(viewPlan, isRevitOwned);
+                            case ViewType.EngineeringPlan:
+                                return StructuralPlanView.FromExisting(viewPlan, isRevitOwned);
+                            case ViewType.AreaPlan:
+                                return AreaPlanView.FromExisting(viewPlan, isRevitOwned);
+                            default:
+                                return UnknownElement.FromExisting(viewPlan, true);
+                        }
+                    }
+
+                case DB.ViewSection viewSection:
+                    return SectionView.FromExisting(viewSection, isRevitOwned);
+
+                case DB.ViewSchedule viewSched:
+                    return ScheduleView.FromExisting(viewSched, isRevitOwned);
+
+                case DB.ViewSheet sheet:
+                    return Sheet.FromExisting(sheet, isRevitOwned);
+
+                case DB.ViewDrafting viewDraft:
+                    return DraftingView.FromExisting(viewDraft, isRevitOwned);
+
+                case DB.Architecture.TopographySurface topoSrf:
+                    return Topography.FromExisting(topoSrf, isRevitOwned);
+
+                case DB.Toposolid topoSol:
+                    return Toposolid.FromExisting(topoSol, isRevitOwned);
+
+                /* put view subclasses above this line */
+                case DB.View view:
+                    {
+                        if (view.ViewType == ViewType.Legend)
+                        {
+                            return Legend.FromExisting(view, isRevitOwned);
+                        }
+                        return UnknownElement.FromExisting(view, true);
+                    }
+
+                case DB.Dimension dim:
+                    return Dimension.FromExisting(dim, isRevitOwned);
+
+                case DB.FilledRegion fillReg:
+                    return FilledRegion.FromExisting(fillReg, isRevitOwned);
+
+                case DB.FillPatternElement fillPat:
+                    return FillPatternElement.FromExisting(fillPat, isRevitOwned);
+
+                case DB.LinePatternElement linePat:
+                    return LinePatternElement.FromExisting(linePat, isRevitOwned);
+
+                case DB.TextNote txtNote:
+                    return TextNote.FromExisting(txtNote, isRevitOwned);
+
+                case DB.IndependentTag tag:
+                    return Tag.FromExisting(tag, isRevitOwned);
+
+                case DB.Revision rev:
+                    return Revision.FromExisting(rev, isRevitOwned);
+
+                case DB.RevisionCloud revCloud:
+                    return RevisionCloud.FromExisting(revCloud, isRevitOwned);
+
+                case DB.ParameterFilterElement parFilter:
+                    return Revit.Filter.ParameterFilterElement.FromExisting(parFilter, isRevitOwned);
+
+                case DB.Architecture.Room room:
+                    return Room.FromExisting(room, isRevitOwned);
+
+                case DB.DetailCurve dCrv:
+                    return DetailCurve.FromExisting(dCrv, isRevitOwned);
+
+                case DB.ImportInstance inst:
+                    return ImportInstance.FromExisting(inst, isRevitOwned);
+
+                case DB.GlobalParameter globalParam:
+                    return GlobalParameter.FromExisting(globalParam, isRevitOwned);
+
+                case DB.FaceWall fWall:
+                    return FaceWall.FromExisting(fWall, isRevitOwned);
+
+                case DB.CurtainSystem curtainSys:
+                    return CurtainSystem.FromExisting(curtainSys, isRevitOwned);
+
+                case DB.Material mat:
+                    return Material.FromExisting(mat, isRevitOwned);
+
+                case DB.Analysis.PathOfTravel pot:
+                    return PathOfTravel.FromExisting(pot, isRevitOwned);
+
+                case DB.Viewport vPort:
+                    return Viewport.FromExisting(vPort, isRevitOwned);
+
+                case DB.ElevationMarker elevMaker:
+                    return ElevationMarker.FromExisting(elevMaker, isRevitOwned);
+
+                case DB.Mechanical.Space space:
+                    return Space.FromExisting(space, isRevitOwned);
+
+                case DB.RoofBase roof:
+                    return Roof.FromExisting(roof, isRevitOwned);
+
+                case DB.ScheduleSheetInstance sched:
+                    return ScheduleOnSheet.FromExisting(sched, isRevitOwned);
+
+                case DB.AppearanceAssetElement ast:
+                    return AppearanceAssetElement.FromExisting(ast, isRevitOwned);
+
+                case DB.RevitLinkInstance linkIst:
+                    return LinkInstance.FromExisting(linkIst, isRevitOwned);
+
                 default:
-                    return UnknownElement.FromExisting(view, true);
+                    return UnknownElement.FromExisting(ele, isRevitOwned);
             }
         }
-
-        public static SectionView Wrap(Autodesk.Revit.DB.ViewSection view, bool isRevitOwned)
-        {
-            return SectionView.FromExisting(view, isRevitOwned);
-        }
-
-        public static ScheduleView Wrap(Autodesk.Revit.DB.ViewSchedule view, bool isRevitOwned)
-        {
-            return ScheduleView.FromExisting(view, isRevitOwned);
-        }
-
-        public static Element Wrap(Autodesk.Revit.DB.View view, bool isRevitOwned)
-        {
-            switch (view.ViewType)
-            {
-                case ViewType.Legend:
-                    return Legend.FromExisting(view, isRevitOwned);
-                default:
-                    return UnknownElement.FromExisting(view, true);
-            }
-        }
-
-        public static Sheet Wrap(Autodesk.Revit.DB.ViewSheet view, bool isRevitOwned)
-        {
-            return Sheet.FromExisting(view, isRevitOwned);
-        }
-
-        public static DraftingView Wrap(Autodesk.Revit.DB.ViewDrafting view, bool isRevitOwned)
-        {
-            return DraftingView.FromExisting(view, isRevitOwned);
-        }
-
-        public static Topography Wrap(Autodesk.Revit.DB.Architecture.TopographySurface topoSurface, bool isRevitOwned)
-        {
-            return Topography.FromExisting(topoSurface, isRevitOwned);
-        }
-
-        public static Toposolid Wrap(Autodesk.Revit.DB.Toposolid toposolid, bool isRevitOwned)
-        {
-            return Toposolid.FromExisting(toposolid, isRevitOwned);
-        }
-
-        public static ToposolidType Wrap(Autodesk.Revit.DB.ToposolidType toposolidType, bool isRevitOwned)
-        {
-            return ToposolidType.FromExisting(toposolidType, isRevitOwned);
-        }
-
-        public static object Wrap(Autodesk.Revit.DB.Panel ele, bool isRevitOwned)
-        {
-            if (AdaptiveComponentInstanceUtils.IsAdaptiveFamilySymbol(ele.Symbol))
-            {
-                return AdaptiveComponent.FromExisting(ele, isRevitOwned);
-            }
-
-           return CurtainPanel.FromExisting(ele, isRevitOwned);
-        }
-
-        public static Mullion Wrap(Autodesk.Revit.DB.Mullion ele, bool isRevitOwned)
-        {
-           return Mullion.FromExisting(ele, isRevitOwned);
-        }
-
-        public static Dimension Wrap(Autodesk.Revit.DB.Dimension ele, bool isRevitOwned)
-        {
-            return Dimension.FromExisting(ele, isRevitOwned);
-        }
-
-        public static DimensionType Wrap(Autodesk.Revit.DB.DimensionType ele, bool isRevitOwned)
-        {
-            return DimensionType.FromExisting(ele, isRevitOwned);
-        }
-
-        public static FilledRegionType Wrap(Autodesk.Revit.DB.FilledRegionType ele, bool isRevitOwned)
-        {
-            return FilledRegionType.FromExisting(ele, isRevitOwned);
-        }
-
-        public static FilledRegion Wrap(Autodesk.Revit.DB.FilledRegion ele, bool isRevitOwned)
-        {
-            return FilledRegion.FromExisting(ele, isRevitOwned);
-	    }
-
-        public static FillPatternElement Wrap(Autodesk.Revit.DB.FillPatternElement ele, bool isRevitOwned)
-        {
-            return FillPatternElement.FromExisting(ele, isRevitOwned);
-        }
-
-        public static LinePatternElement Wrap(Autodesk.Revit.DB.LinePatternElement ele, bool isRevitOwned)
-        {
-            return LinePatternElement.FromExisting(ele, isRevitOwned);
-        }
-
-        public static TextNote Wrap(Autodesk.Revit.DB.TextNote ele, bool isRevitOwned)
-        {
-            return TextNote.FromExisting(ele, isRevitOwned);
-        }
-
-        public static Tag Wrap(Autodesk.Revit.DB.IndependentTag ele, bool isRevitOwned)
-        {
-            return Tag.FromExisting(ele, isRevitOwned);
-        }
-
-        public static TextNoteType Wrap(Autodesk.Revit.DB.TextNoteType ele, bool isRevitOwned)
-        {
-            return TextNoteType.FromExisting(ele, isRevitOwned);
-		}
-
-        public static Revision Wrap(Autodesk.Revit.DB.Revision ele, bool isRevitOwned)
-        {
-            return Revision.FromExisting(ele, isRevitOwned);
-        }
-
-        public static RevisionCloud Wrap(Autodesk.Revit.DB.RevisionCloud ele, bool isRevitOwned)
-        {
-            return RevisionCloud.FromExisting(ele, isRevitOwned);
-	}
-
-        public static Revit.Filter.ParameterFilterElement Wrap(Autodesk.Revit.DB.ParameterFilterElement ele, bool isRevitOwned)
-        {
-            return Revit.Filter.ParameterFilterElement.FromExisting(ele, isRevitOwned);
-    	}
-
-        public static Room Wrap(Autodesk.Revit.DB.Architecture.Room ele, bool isRevitOwned)
-        {
-            return Room.FromExisting(ele, isRevitOwned);
-        }
-
-        public static DetailCurve Wrap(Autodesk.Revit.DB.DetailCurve ele, bool isRevitOwned)
-        {
-            return DetailCurve.FromExisting(ele, isRevitOwned);
-
-        }
-
-        public static ImportInstance Wrap(Autodesk.Revit.DB.ImportInstance ele, bool isRevitOwned)
-        {
-            return ImportInstance.FromExisting(ele, isRevitOwned);
-        }
-
-        public static GlobalParameter Wrap(Autodesk.Revit.DB.GlobalParameter ele, bool isRevitOwned)
-        {
-            return GlobalParameter.FromExisting(ele, isRevitOwned);
-        }
-
-        public static FaceWall Wrap(Autodesk.Revit.DB.FaceWall ele, bool isRevitOwned)
-        {
-            return FaceWall.FromExisting(ele, isRevitOwned);
-        }
-
-        public static CurtainSystem Wrap(Autodesk.Revit.DB.CurtainSystem ele, bool isRevitOwned)
-        {
-            return CurtainSystem.FromExisting(ele, isRevitOwned);
-        }
-
-        public static Material Wrap(Autodesk.Revit.DB.Material ele, bool isRevitOwned)
-        {
-            return Material.FromExisting(ele, isRevitOwned);
-        }
-
-        public static PathOfTravel Wrap(Autodesk.Revit.DB.Analysis.PathOfTravel ele, bool isRevitOwned)
-        {
-            return PathOfTravel.FromExisting(ele, isRevitOwned);
-        }
-
-        public static Viewport Wrap(Autodesk.Revit.DB.Viewport ele, bool isRevitOwned)
-        {
-            return Viewport.FromExisting(ele, isRevitOwned);
-        }
-
-        public static ElevationMarker Wrap(Autodesk.Revit.DB.ElevationMarker ele, bool isRevitOwned)
-        {
-            return ElevationMarker.FromExisting(ele, isRevitOwned);
-        }
-
-        public static Space Wrap(Autodesk.Revit.DB.Mechanical.Space ele, bool isRevitOwned)
-        {
-            return Space.FromExisting(ele, isRevitOwned);
-        }
-
-        public static RoofType Wrap(Autodesk.Revit.DB.RoofType ele, bool isRevitOwned)
-        {
-            return RoofType.FromExisting(ele, isRevitOwned);
-        }
-
-        public static Roof Wrap(Autodesk.Revit.DB.RoofBase ele, bool isRevitOwned)
-        {
-            return Roof.FromExisting(ele, isRevitOwned);
-        }
-
-        public static ScheduleOnSheet Wrap(Autodesk.Revit.DB.ScheduleSheetInstance ele, bool isRevitOwned)
-        {
-            return ScheduleOnSheet.FromExisting(ele, isRevitOwned);
-        }
-
-        public static AppearanceAssetElement Wrap(Autodesk.Revit.DB.AppearanceAssetElement ele, bool isRevitOwned)
-        {
-            return AppearanceAssetElement.FromExisting(ele, isRevitOwned);
-        }
-
-        public static LinkInstance Wrap(Autodesk.Revit.DB.RevitLinkInstance ele, bool isRevitOwned)
-        {
-            return LinkInstance.FromExisting(ele, isRevitOwned);
-        }
-
-        #endregion
     }
 
 }

--- a/src/Libraries/RevitNodes/Elements/InternalUtilities/ElementWrapper.cs
+++ b/src/Libraries/RevitNodes/Elements/InternalUtilities/ElementWrapper.cs
@@ -1,4 +1,5 @@
-﻿using Autodesk.DesignScript.Runtime;
+﻿using System;
+using Autodesk.DesignScript.Runtime;
 using Autodesk.Revit.DB;
 using Revit.Elements.Views;
 using DB = Autodesk.Revit.DB;
@@ -283,6 +284,458 @@ namespace Revit.Elements
                     return UnknownElement.FromExisting(ele, isRevitOwned);
             }
         }
-    }
 
+        #region Wrap methods
+
+        [Obsolete("Please use ToDsType instead")]
+        public static UnknownElement Wrap(Autodesk.Revit.DB.Element element, bool isRevitOwned)
+        {
+            return UnknownElement.FromExisting(element, isRevitOwned);
+        }
+
+        [Obsolete("Please use ToDsType instead")]
+        public static AbstractFamilyInstance Wrap(Autodesk.Revit.DB.FamilyInstance ele, bool isRevitOwned)
+        {
+            if (AdaptiveComponentInstanceUtils.HasAdaptiveFamilySymbol(ele))
+            {
+                return AdaptiveComponent.FromExisting(ele, isRevitOwned);
+            }
+
+            if (ele.StructuralType != Autodesk.Revit.DB.Structure.StructuralType.NonStructural &&
+                ele.StructuralType != Autodesk.Revit.DB.Structure.StructuralType.Footing)
+            {
+                return StructuralFraming.FromExisting(ele, isRevitOwned);
+            }
+
+            return FamilyInstance.FromExisting(ele, isRevitOwned);
+        }
+
+        [Obsolete("Please use ToDsType instead")]
+        public static Area Wrap(Autodesk.Revit.DB.Area ele, bool isRevitOwned)
+        {
+            return Area.FromExisting(ele, isRevitOwned);
+        }
+
+        [Obsolete("Please use ToDsType instead")]
+        public static Ceiling Wrap(Autodesk.Revit.DB.Ceiling ele, bool isRevitOwned)
+        {
+            return Ceiling.FromExisting(ele, isRevitOwned);
+        }
+
+        [Obsolete("Please use ToDsType instead")]
+        public static CeilingType Wrap(Autodesk.Revit.DB.CeilingType ele, bool isRevitOwned)
+        {
+            return CeilingType.FromExisting(ele, isRevitOwned);
+        }
+
+        [Obsolete("Please use ToDsType instead")]
+        public static DirectShape Wrap(Autodesk.Revit.DB.DirectShape ele, bool isRevitOwned)
+        {
+            return DirectShape.FromExisting(ele, isRevitOwned);
+        }
+
+        [Obsolete("Please use ToDsType instead")]
+        public static DividedPath Wrap(Autodesk.Revit.DB.DividedPath ele, bool isRevitOwned)
+        {
+            return DividedPath.FromExisting(ele, isRevitOwned);
+        }
+
+        [Obsolete("Please use ToDsType instead")]
+        public static ElementType Wrap(Autodesk.Revit.DB.ElementType elementType, bool isRevitOwned)
+        {
+            return ElementType.FromExisting(elementType, isRevitOwned);
+        }
+
+        [Obsolete("Please use ToDsType instead")]
+        public static DividedSurface Wrap(Autodesk.Revit.DB.DividedSurface ele, bool isRevitOwned)
+        {
+            return DividedSurface.FromExisting(ele, isRevitOwned);
+        }
+
+        [Obsolete("Please use ToDsType instead")]
+        public static Family Wrap(Autodesk.Revit.DB.Family ele, bool isRevitOwned)
+        {
+            return Family.FromExisting(ele, isRevitOwned);
+        }
+
+        [Obsolete("Please use ToDsType instead")]
+        public static FamilyType Wrap(Autodesk.Revit.DB.FamilySymbol ele, bool isRevitOwned)
+        {
+            return FamilyType.FromExisting(ele, isRevitOwned);
+        }
+
+        [Obsolete("Please use ToDsType instead")]
+        public static Floor Wrap(Autodesk.Revit.DB.Floor ele, bool isRevitOwned)
+        {
+            return Floor.FromExisting(ele, isRevitOwned);
+        }
+
+        [Obsolete("Please use ToDsType instead")]
+        public static FloorType Wrap(Autodesk.Revit.DB.FloorType ele, bool isRevitOwned)
+        {
+            return FloorType.FromExisting(ele, isRevitOwned);
+        }
+
+        [Obsolete("Please use ToDsType instead")]
+        public static Form Wrap(Autodesk.Revit.DB.Form ele, bool isRevitOwned)
+        {
+            return Form.FromExisting(ele, isRevitOwned);
+        }
+
+        [SupressImportIntoVM]
+        [Obsolete("Please use ToDsType instead")]
+        public static FreeForm Wrap(Autodesk.Revit.DB.FreeFormElement ele, bool isRevitOwned)
+        {
+            return FreeForm.FromExisting(ele, isRevitOwned);
+        }
+
+        [Obsolete("Please use ToDsType instead")]
+        public static Grid Wrap(Autodesk.Revit.DB.Grid ele, bool isRevitOwned)
+        {
+            return Grid.FromExisting(ele, isRevitOwned);
+        }
+
+        [Obsolete("Please use ToDsType instead")]
+        public static Group Wrap(Autodesk.Revit.DB.Group ele, bool isRevitOwned)
+        {
+            return Group.FromExisting(ele, isRevitOwned);
+        }
+
+        [Obsolete("Please use ToDsType instead")]
+        public static Level Wrap(Autodesk.Revit.DB.Level ele, bool isRevitOwned)
+        {
+            return Level.FromExisting(ele, isRevitOwned);
+        }
+
+        [Obsolete("Please use ToDsType instead")]
+        public static ModelCurve Wrap(Autodesk.Revit.DB.ModelCurve ele, bool isRevitOwned)
+        {
+            return ModelCurve.FromExisting(ele, isRevitOwned);
+        }
+
+        [Obsolete("Please use ToDsType instead")]
+        public static CurveByPoints Wrap(Autodesk.Revit.DB.CurveByPoints ele, bool isRevitOwned)
+        {
+            return CurveByPoints.FromExisting(ele, isRevitOwned);
+        }
+
+        [Obsolete("Please use ToDsType instead")]
+        public static ModelText Wrap(Autodesk.Revit.DB.ModelText ele, bool isRevitOwned)
+        {
+            return ModelText.FromExisting(ele, isRevitOwned);
+        }
+
+        [Obsolete("Please use ToDsType instead")]
+        public static ModelTextType Wrap(Autodesk.Revit.DB.ModelTextType ele, bool isRevitOwned)
+        {
+            return ModelTextType.FromExisting(ele, isRevitOwned);
+        }
+
+        [Obsolete("Please use ToDsType instead")]
+        public static ReferencePlane Wrap(Autodesk.Revit.DB.ReferencePlane ele, bool isRevitOwned)
+        {
+            return ReferencePlane.FromExisting(ele, isRevitOwned);
+        }
+
+        [Obsolete("Please use ToDsType instead")]
+        public static ReferencePoint Wrap(Autodesk.Revit.DB.ReferencePoint ele, bool isRevitOwned)
+        {
+            return ReferencePoint.FromExisting(ele, isRevitOwned);
+        }
+
+        [Obsolete("Please use ToDsType instead")]
+        public static SketchPlane Wrap(Autodesk.Revit.DB.SketchPlane ele, bool isRevitOwned)
+        {
+            return SketchPlane.FromExisting(ele, isRevitOwned);
+        }
+
+        [Obsolete("Please use ToDsType instead")]
+        public static Wall Wrap(Autodesk.Revit.DB.Wall ele, bool isRevitOwned)
+        {
+            return Wall.FromExisting(ele, isRevitOwned);
+        }
+
+        [Obsolete("Please use ToDsType instead")]
+        public static WallType Wrap(Autodesk.Revit.DB.WallType ele, bool isRevitOwned)
+        {
+            return WallType.FromExisting(ele, isRevitOwned);
+        }
+
+        [Obsolete("Please use ToDsType instead")]
+        public static View3D Wrap(Autodesk.Revit.DB.View3D view, bool isRevitOwned)
+        {
+            if (!view.IsTemplate)
+            {
+                if (view.IsPerspective)
+                    return PerspectiveView.FromExisting(view, isRevitOwned);
+                else
+                    return AxonometricView.FromExisting(view, isRevitOwned);
+            }
+            else if (view.IsTemplate)
+            {
+                return View3DTemplate.FromExisting(view, isRevitOwned);
+            }
+            return null;
+        }
+
+        [Obsolete("Please use ToDsType instead")]
+        public static Element Wrap(Autodesk.Revit.DB.ViewPlan view, bool isRevitOwned)
+        {
+            switch (view.ViewType)
+            {
+                case ViewType.CeilingPlan:
+                    return CeilingPlanView.FromExisting(view, isRevitOwned);
+                case ViewType.FloorPlan:
+                    return FloorPlanView.FromExisting(view, isRevitOwned);
+                case ViewType.EngineeringPlan:
+                    return StructuralPlanView.FromExisting(view, isRevitOwned);
+                case ViewType.AreaPlan:
+                    return AreaPlanView.FromExisting(view, isRevitOwned);
+                default:
+                    return UnknownElement.FromExisting(view, true);
+            }
+        }
+
+        [Obsolete("Please use ToDsType instead")]
+        public static SectionView Wrap(Autodesk.Revit.DB.ViewSection view, bool isRevitOwned)
+        {
+            return SectionView.FromExisting(view, isRevitOwned);
+        }
+
+        [Obsolete("Please use ToDsType instead")]
+        public static ScheduleView Wrap(Autodesk.Revit.DB.ViewSchedule view, bool isRevitOwned)
+        {
+            return ScheduleView.FromExisting(view, isRevitOwned);
+        }
+
+        [Obsolete("Please use ToDsType instead")]
+        public static Element Wrap(Autodesk.Revit.DB.View view, bool isRevitOwned)
+        {
+            switch (view.ViewType)
+            {
+                case ViewType.Legend:
+                    return Legend.FromExisting(view, isRevitOwned);
+                default:
+                    return UnknownElement.FromExisting(view, true);
+            }
+        }
+
+        [Obsolete("Please use ToDsType instead")]
+        public static Sheet Wrap(Autodesk.Revit.DB.ViewSheet view, bool isRevitOwned)
+        {
+            return Sheet.FromExisting(view, isRevitOwned);
+        }
+
+        [Obsolete("Please use ToDsType instead")]
+        public static DraftingView Wrap(Autodesk.Revit.DB.ViewDrafting view, bool isRevitOwned)
+        {
+            return DraftingView.FromExisting(view, isRevitOwned);
+        }
+
+        [Obsolete("Please use ToDsType instead")]
+        public static Topography Wrap(Autodesk.Revit.DB.Architecture.TopographySurface topoSurface, bool isRevitOwned)
+        {
+            return Topography.FromExisting(topoSurface, isRevitOwned);
+        }
+
+        [Obsolete("Please use ToDsType instead")]
+        public static Toposolid Wrap(Autodesk.Revit.DB.Toposolid toposolid, bool isRevitOwned)
+        {
+            return Toposolid.FromExisting(toposolid, isRevitOwned);
+        }
+
+        [Obsolete("Please use ToDsType instead")]
+        public static ToposolidType Wrap(Autodesk.Revit.DB.ToposolidType toposolidType, bool isRevitOwned)
+        {
+            return ToposolidType.FromExisting(toposolidType, isRevitOwned);
+        }
+
+        [Obsolete("Please use ToDsType instead")]
+        public static object Wrap(Autodesk.Revit.DB.Panel ele, bool isRevitOwned)
+        {
+            if (AdaptiveComponentInstanceUtils.IsAdaptiveFamilySymbol(ele.Symbol))
+            {
+                return AdaptiveComponent.FromExisting(ele, isRevitOwned);
+            }
+
+            return CurtainPanel.FromExisting(ele, isRevitOwned);
+        }
+
+        [Obsolete("Please use ToDsType instead")]
+        public static Mullion Wrap(Autodesk.Revit.DB.Mullion ele, bool isRevitOwned)
+        {
+            return Mullion.FromExisting(ele, isRevitOwned);
+        }
+
+        [Obsolete("Please use ToDsType instead")]
+        public static Dimension Wrap(Autodesk.Revit.DB.Dimension ele, bool isRevitOwned)
+        {
+            return Dimension.FromExisting(ele, isRevitOwned);
+        }
+
+        [Obsolete("Please use ToDsType instead")]
+        public static DimensionType Wrap(Autodesk.Revit.DB.DimensionType ele, bool isRevitOwned)
+        {
+            return DimensionType.FromExisting(ele, isRevitOwned);
+        }
+
+        [Obsolete("Please use ToDsType instead")]
+        public static FilledRegionType Wrap(Autodesk.Revit.DB.FilledRegionType ele, bool isRevitOwned)
+        {
+            return FilledRegionType.FromExisting(ele, isRevitOwned);
+        }
+
+        [Obsolete("Please use ToDsType instead")]
+        public static FilledRegion Wrap(Autodesk.Revit.DB.FilledRegion ele, bool isRevitOwned)
+        {
+            return FilledRegion.FromExisting(ele, isRevitOwned);
+        }
+
+        [Obsolete("Please use ToDsType instead")]
+        public static FillPatternElement Wrap(Autodesk.Revit.DB.FillPatternElement ele, bool isRevitOwned)
+        {
+            return FillPatternElement.FromExisting(ele, isRevitOwned);
+        }
+
+        [Obsolete("Please use ToDsType instead")]
+        public static LinePatternElement Wrap(Autodesk.Revit.DB.LinePatternElement ele, bool isRevitOwned)
+        {
+            return LinePatternElement.FromExisting(ele, isRevitOwned);
+        }
+
+        [Obsolete("Please use ToDsType instead")]
+        public static TextNote Wrap(Autodesk.Revit.DB.TextNote ele, bool isRevitOwned)
+        {
+            return TextNote.FromExisting(ele, isRevitOwned);
+        }
+
+        [Obsolete("Please use ToDsType instead")]
+        public static Tag Wrap(Autodesk.Revit.DB.IndependentTag ele, bool isRevitOwned)
+        {
+            return Tag.FromExisting(ele, isRevitOwned);
+        }
+
+        [Obsolete("Please use ToDsType instead")]
+        public static TextNoteType Wrap(Autodesk.Revit.DB.TextNoteType ele, bool isRevitOwned)
+        {
+            return TextNoteType.FromExisting(ele, isRevitOwned);
+        }
+
+        [Obsolete("Please use ToDsType instead")]
+        public static Revision Wrap(Autodesk.Revit.DB.Revision ele, bool isRevitOwned)
+        {
+            return Revision.FromExisting(ele, isRevitOwned);
+        }
+
+        [Obsolete("Please use ToDsType instead")]
+        public static RevisionCloud Wrap(Autodesk.Revit.DB.RevisionCloud ele, bool isRevitOwned)
+        {
+            return RevisionCloud.FromExisting(ele, isRevitOwned);
+        }
+
+        [Obsolete("Please use ToDsType instead")]
+        public static Revit.Filter.ParameterFilterElement Wrap(Autodesk.Revit.DB.ParameterFilterElement ele, bool isRevitOwned)
+        {
+            return Revit.Filter.ParameterFilterElement.FromExisting(ele, isRevitOwned);
+        }
+
+        [Obsolete("Please use ToDsType instead")]
+        public static Room Wrap(Autodesk.Revit.DB.Architecture.Room ele, bool isRevitOwned)
+        {
+            return Room.FromExisting(ele, isRevitOwned);
+        }
+
+        [Obsolete("Please use ToDsType instead")]
+        public static DetailCurve Wrap(Autodesk.Revit.DB.DetailCurve ele, bool isRevitOwned)
+        {
+            return DetailCurve.FromExisting(ele, isRevitOwned);
+
+        }
+
+        [Obsolete("Please use ToDsType instead")]
+        public static ImportInstance Wrap(Autodesk.Revit.DB.ImportInstance ele, bool isRevitOwned)
+        {
+            return ImportInstance.FromExisting(ele, isRevitOwned);
+        }
+
+        [Obsolete("Please use ToDsType instead")]
+        public static GlobalParameter Wrap(Autodesk.Revit.DB.GlobalParameter ele, bool isRevitOwned)
+        {
+            return GlobalParameter.FromExisting(ele, isRevitOwned);
+        }
+
+        [Obsolete("Please use ToDsType instead")]
+        public static FaceWall Wrap(Autodesk.Revit.DB.FaceWall ele, bool isRevitOwned)
+        {
+            return FaceWall.FromExisting(ele, isRevitOwned);
+        }
+
+        [Obsolete("Please use ToDsType instead")]
+        public static CurtainSystem Wrap(Autodesk.Revit.DB.CurtainSystem ele, bool isRevitOwned)
+        {
+            return CurtainSystem.FromExisting(ele, isRevitOwned);
+        }
+
+        [Obsolete("Please use ToDsType instead")]
+        public static Material Wrap(Autodesk.Revit.DB.Material ele, bool isRevitOwned)
+        {
+            return Material.FromExisting(ele, isRevitOwned);
+        }
+
+        [Obsolete("Please use ToDsType instead")]
+        public static PathOfTravel Wrap(Autodesk.Revit.DB.Analysis.PathOfTravel ele, bool isRevitOwned)
+        {
+            return PathOfTravel.FromExisting(ele, isRevitOwned);
+        }
+
+        [Obsolete("Please use ToDsType instead")]
+        public static Viewport Wrap(Autodesk.Revit.DB.Viewport ele, bool isRevitOwned)
+        {
+            return Viewport.FromExisting(ele, isRevitOwned);
+        }
+
+        [Obsolete("Please use ToDsType instead")]
+        public static ElevationMarker Wrap(Autodesk.Revit.DB.ElevationMarker ele, bool isRevitOwned)
+        {
+            return ElevationMarker.FromExisting(ele, isRevitOwned);
+        }
+
+        [Obsolete("Please use ToDsType instead")]
+        public static Space Wrap(Autodesk.Revit.DB.Mechanical.Space ele, bool isRevitOwned)
+        {
+            return Space.FromExisting(ele, isRevitOwned);
+        }
+
+        [Obsolete("Please use ToDsType instead")]
+        public static RoofType Wrap(Autodesk.Revit.DB.RoofType ele, bool isRevitOwned)
+        {
+            return RoofType.FromExisting(ele, isRevitOwned);
+        }
+
+        [Obsolete("Please use ToDsType instead")]
+        public static Roof Wrap(Autodesk.Revit.DB.RoofBase ele, bool isRevitOwned)
+        {
+            return Roof.FromExisting(ele, isRevitOwned);
+        }
+
+        [Obsolete("Please use ToDsType instead")]
+        public static ScheduleOnSheet Wrap(Autodesk.Revit.DB.ScheduleSheetInstance ele, bool isRevitOwned)
+        {
+            return ScheduleOnSheet.FromExisting(ele, isRevitOwned);
+        }
+
+        [Obsolete("Please use ToDsType instead")]
+        public static AppearanceAssetElement Wrap(Autodesk.Revit.DB.AppearanceAssetElement ele, bool isRevitOwned)
+        {
+            return AppearanceAssetElement.FromExisting(ele, isRevitOwned);
+        }
+
+        [Obsolete("Please use ToDsType instead")]
+        public static LinkInstance Wrap(Autodesk.Revit.DB.RevitLinkInstance ele, bool isRevitOwned)
+        {
+            return LinkInstance.FromExisting(ele, isRevitOwned);
+        }
+
+        #endregion
+    }
 }

--- a/src/Libraries/RevitNodes/Elements/InternalUtilities/ElementWrapper.cs
+++ b/src/Libraries/RevitNodes/Elements/InternalUtilities/ElementWrapper.cs
@@ -462,7 +462,7 @@ namespace Revit.Elements
         }
 
         [Obsolete("Please use ToDsType instead")]
-        public static View3D Wrap(Autodesk.Revit.DB.View3D view, bool isRevitOwned)
+        public static Revit.Elements.Views.View3D Wrap(Autodesk.Revit.DB.View3D view, bool isRevitOwned)
         {
             if (!view.IsTemplate)
             {

--- a/src/Libraries/RevitNodes/Elements/Tag.cs
+++ b/src/Libraries/RevitNodes/Elements/Tag.cs
@@ -1,11 +1,11 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Linq;
 using Autodesk.DesignScript.Runtime;
 using Autodesk.Revit.DB;
 using Revit.GeometryConversion;
 using RevitServices.Persistence;
 using RevitServices.Transactions;
-using System.Collections.Generic;
-using System.Linq;
 
 namespace Revit.Elements
 {
@@ -113,7 +113,7 @@ namespace Revit.Elements
             var hostElementIds = new List<ElementId>();
             var linkedElementIds = new List<ElementId>();
 
-            if(tagElem != null)
+            if (tagElem != null)
             {
                 hostElementIds.AddRange(tagElem.GetTaggedElementIds().Select(x => x.HostElementId));
                 linkedElementIds.AddRange(tagElem.GetTaggedElementIds().Select(x => x.LinkedElementId));
@@ -255,7 +255,7 @@ namespace Revit.Elements
         /// <search>
         /// tagelement,annotate,documentation
         /// </search>
-        public static Tag ByElement(Revit.Elements.Views.View view, Element element, bool horizontal, bool addLeader, string horizontalAlignment, string verticalAlignment, [DefaultArgument("Autodesk.DesignScript.Geometry.Vector.ByCoordinates(0,0,0)")]Autodesk.DesignScript.Geometry.Vector offset, bool isOffset = true)
+        public static Tag ByElement(Revit.Elements.Views.View view, Element element, bool horizontal, bool addLeader, string horizontalAlignment, string verticalAlignment, [DefaultArgument("Autodesk.DesignScript.Geometry.Vector.ByCoordinates(0,0,0)")] Autodesk.DesignScript.Geometry.Vector offset, bool isOffset = true)
         {
             Autodesk.Revit.DB.HorizontalAlignmentStyle horizontalAlignmentStyle = HorizontalAlignmentStyle.Center;
             if (!Enum.TryParse<Autodesk.Revit.DB.HorizontalAlignmentStyle>(horizontalAlignment, out horizontalAlignmentStyle))
@@ -324,7 +324,7 @@ namespace Revit.Elements
         /// <search>
         /// tagelement,annotate,documentation,tagoffset,movetag
         /// </search>
-        public static Tag ByElementAndOffset(Revit.Elements.Views.View view, Element element, [DefaultArgument("Autodesk.DesignScript.Geometry.Vector.ByCoordinates(0,0,0)")]Autodesk.DesignScript.Geometry.Vector offset, string horizontalAlignment = "Center", string verticalAlignment = "Middle", bool horizontal = true, bool addLeader = false)
+        public static Tag ByElementAndOffset(Revit.Elements.Views.View view, Element element, [DefaultArgument("Autodesk.DesignScript.Geometry.Vector.ByCoordinates(0,0,0)")] Autodesk.DesignScript.Geometry.Vector offset, string horizontalAlignment = "Center", string verticalAlignment = "Middle", bool horizontal = true, bool addLeader = false)
         {
             Autodesk.Revit.DB.HorizontalAlignmentStyle horizontalAlignmentStyle = HorizontalAlignmentStyle.Center;
             if (!Enum.TryParse<Autodesk.Revit.DB.HorizontalAlignmentStyle>(horizontalAlignment, out horizontalAlignmentStyle))
@@ -339,7 +339,7 @@ namespace Revit.Elements
             }
 
             Autodesk.Revit.DB.View revitView = (Autodesk.Revit.DB.View)view.InternalElement;
-            
+
             // Tagging elements by element category
             Autodesk.Revit.DB.TagMode tagMode = TagMode.TM_ADDBY_CATEGORY;
 
@@ -373,10 +373,11 @@ namespace Revit.Elements
         /// </summary>
         public Revit.Elements.Element TaggedElement
         {
-            get {
+            get
+            {
                 var eles = this.InternalTextNote.GetTaggedLocalElements();
                 if (eles.Count == 1)
-                    return (Revit.Elements.Element)ElementWrapper.Wrap(eles.First(), true);
+                    return eles.First().ToDSType(true);
                 else
                     throw new Exception(Properties.Resources.GetTaggedLocalElements);
             }
@@ -407,7 +408,7 @@ namespace Revit.Elements
             TransactionManager.Instance.EnsureInTransaction(document);
 
             tagElem.TagHeadPosition = point;
-            
+
             double rotation = (tagElem.TagOrientation == TagOrientation.Horizontal) ? 0 : 90;
             InternalSetType(tagElem.TagText, tagElem.TagHeadPosition, rotation);
 
@@ -469,7 +470,7 @@ namespace Revit.Elements
             get
             {
                 if (this.InternalTextNote.HasLeader)
-                    if(this.InternalTextNote.LeaderEndCondition.Equals(LeaderEndCondition.Free))
+                    if (this.InternalTextNote.LeaderEndCondition.Equals(LeaderEndCondition.Free))
                     {
                         var refs = InternalTextNote.GetTaggedReferences();
                         if (refs.Count == 1)
@@ -477,7 +478,7 @@ namespace Revit.Elements
                         else
                             throw new Exception(Properties.Resources.GetTaggedReferences);
                     }
-                        
+
                 return null;
             }
         }
@@ -545,7 +546,7 @@ namespace Revit.Elements
         internal static Tag FromExisting(Autodesk.Revit.DB.IndependentTag instance, bool isRevitOwned)
         {
             return new Tag(instance)
-            { 
+            {
                 IsRevitOwned = isRevitOwned
             };
         }

--- a/src/Libraries/RevitNodes/Elements/Views/Sheet.cs
+++ b/src/Libraries/RevitNodes/Elements/Views/Sheet.cs
@@ -5,9 +5,9 @@ using Autodesk.DesignScript.Geometry;
 using Autodesk.Revit.DB;
 using DynamoServices;
 using Nuclex.Game.Packing;
+using Revit.GeometryConversion;
 using RevitServices.Persistence;
 using RevitServices.Transactions;
-using Revit.GeometryConversion;
 
 namespace Revit.Elements.Views
 {
@@ -39,7 +39,7 @@ namespace Revit.Elements.Views
 
         public override void Dispose()
         {
-            if (DuplicateViews != null) 
+            if (DuplicateViews != null)
             {
                 if (this.DuplicateViews.Any())
                 {
@@ -47,7 +47,7 @@ namespace Revit.Elements.Views
                         view.Dispose();
                 }
             }
-            
+
             DuplicateViews = null;
             base.Dispose();
         }
@@ -91,7 +91,7 @@ namespace Revit.Elements.Views
 
         private Sheet(string sheetName, string sheetNumber, Autodesk.Revit.DB.FamilySymbol titleBlockFamilySymbol, IEnumerable<Autodesk.Revit.DB.View> views, IEnumerable<XYZ> locations)
         {
-            SafeInit(() => InitSheet(sheetName,sheetNumber,titleBlockFamilySymbol,views,locations));
+            SafeInit(() => InitSheet(sheetName, sheetNumber, titleBlockFamilySymbol, views, locations));
         }
 
         #endregion
@@ -685,7 +685,7 @@ namespace Revit.Elements.Views
                 throw new ArgumentException(Properties.Resources.Sheet_ViewLocationMismatch);
             }
 
-            return new Sheet(sheetName, sheetNumber, titleBlockFamilyType.InternalFamilySymbol, views.Select(x => x.InternalView), locations.Select(x =>x.ToXyz()));
+            return new Sheet(sheetName, sheetNumber, titleBlockFamilyType.InternalFamilySymbol, views.Select(x => x.InternalView), locations.Select(x => x.ToXyz()));
         }
 
         /// <summary>
@@ -705,7 +705,7 @@ namespace Revit.Elements.Views
                 throw new ArgumentNullException("view");
             }
 
-            if (location == null) 
+            if (location == null)
             {
                 throw new ArgumentNullException("location");
             }
@@ -724,7 +724,7 @@ namespace Revit.Elements.Views
         /// <param name="suffix">When prefix and suffix are both empty, suffix will set a default value - " - Copy".</param>
         /// <returns></returns>
         public static Sheet DuplicateSheet(Sheet sheet, bool duplicateWithContents = false, bool duplicateWithView = false, string viewDuplicateOption = "Duplicate", string prefix = "", string suffix = "")
-        {            
+        {
             if (sheet == null)
                 throw new ArgumentNullException(nameof(sheet));
 
@@ -739,7 +739,7 @@ namespace Revit.Elements.Views
 
             try
             {
-                RevitServices.Transactions.TransactionManager.Instance.EnsureInTransaction(Application.Document.Current.InternalDocument);                
+                RevitServices.Transactions.TransactionManager.Instance.EnsureInTransaction(Application.Document.Current.InternalDocument);
 
                 var oldElements = ElementBinder.GetElementsFromTrace<Autodesk.Revit.DB.Element>(Document);
                 List<ElementId> elementIds = new List<ElementId>();
@@ -752,17 +752,17 @@ namespace Revit.Elements.Views
                     foreach (var element in oldElements)
                     {
                         elementIds.Add(element.Id);
-                        if(element is ViewSheet)
+                        if (element is ViewSheet)
                         {
                             var oldSheet = (element as ViewSheet).ToDSType(false) as Sheet;
                             if (oldSheet.SheetNumber.Equals(newSheetNumber))
                             {
-                                if ((duplicateWithView && oldElements.Count() > 1) || (!duplicateWithView && oldElements.Count() == 1))  
+                                if ((duplicateWithView && oldElements.Count() > 1) || (!duplicateWithView && oldElements.Count() == 1))
                                 {
                                     newSheet = oldSheet;
                                     TraceElements.AddRange(oldElements);
                                 }
-                                if(newSheet != null)
+                                if (newSheet != null)
                                 {
                                     if (duplicateWithContents)
                                         DuplicateSheetAnnotations(sheet, newSheet);
@@ -773,7 +773,7 @@ namespace Revit.Elements.Views
                             }
                         }
                     }
-                    if(newSheet == null)
+                    if (newSheet == null)
                     {
                         Autodesk.Revit.UI.UIDocument uIDocument = new Autodesk.Revit.UI.UIDocument(Document);
                         var openedViews = uIDocument.GetOpenUIViews().ToList();
@@ -789,7 +789,7 @@ namespace Revit.Elements.Views
                             }
                         }
                         Document.Delete(elementIds);
-                    }                    
+                    }
                 }
 
                 if (newSheet == null && TraceElements.Count == 0)
@@ -797,7 +797,7 @@ namespace Revit.Elements.Views
                     // Create a new Sheet with different SheetNumber
                     var titleBlockElement = sheet.TitleBlock.First() as FamilyInstance;
                     FamilySymbol TitleBlock = titleBlockElement.InternalFamilyInstance.Symbol;
-                    FamilyType titleBlockFamilyType = ElementWrapper.Wrap(TitleBlock, true);
+                    FamilyType titleBlockFamilyType = TitleBlock.ToDSType(true) as FamilyType;
 
                     if (!CheckUniqueSheetNumber(newSheetNumber))
                     {
@@ -813,9 +813,9 @@ namespace Revit.Elements.Views
                     TraceElements.Add(newSheet.InternalElement);
 
                     // Copy Annotation Elements from sheet to new sheet by ElementTransformUtils.CopyElements
-                    if(duplicateWithContents)
+                    if (duplicateWithContents)
                         DuplicateSheetAnnotations(sheet, newSheet);
-                    
+
                     if (duplicateWithView)
                     {
                         // Copy ScheduleSheetInstance except RevisionSchedule from sheet to new sheet by ElementTransformUtils.CopyElements
@@ -824,21 +824,21 @@ namespace Revit.Elements.Views
                         // Duplicate Viewport in sheet and place on new sheet
                         TraceElements.AddRange(DuplicateViewport(sheet, newSheet, Option, prefix, suffix));
                     }
-                        
-                }                
-                                
+
+                }
+
                 ElementBinder.SetElementsForTrace(TraceElements);
                 RevitServices.Transactions.TransactionManager.Instance.TransactionTaskDone();
             }
             catch (Exception e)
             {
-                if(newSheet != null)
+                if (newSheet != null)
                 {
                     newSheet.Dispose();
                 }
                 throw e;
             }
-            
+
             return newSheet;
         }
 
@@ -873,7 +873,7 @@ namespace Revit.Elements.Views
                 BuiltInParameter.SHEET_CHECKED_BY,
                 BuiltInParameter.SHEET_DRAWN_BY
             };
-            foreach(var parameter in Filters)
+            foreach (var parameter in Filters)
             {
                 var oldParam = oldSheet.InternalViewSheet.get_Parameter(parameter);
                 var value = oldParam.AsString();
@@ -894,12 +894,12 @@ namespace Revit.Elements.Views
             };
             List<ElementId> list = new List<ElementId>();
             List<ElementId> currentList = new List<ElementId>();
-            foreach(var category in Filters)
+            foreach (var category in Filters)
             {
                 list.AddRange(new FilteredElementCollector(Document, oldSheet.InternalElementId).OfCategory(category).ToElementIds());
                 currentList.AddRange(new FilteredElementCollector(Document, newSheet.InternalElementId).OfCategory(category).ToElementIds());
             }
-            if(list.Any<ElementId>())
+            if (list.Any<ElementId>())
             {
                 if (currentList.Any<ElementId>() && currentList.Count == list.Count)
                     return;
@@ -924,9 +924,9 @@ namespace Revit.Elements.Views
             {
                 list.AddRange(new FilteredElementCollector(Document, sheet.InternalElementId).OfCategory(category).ToElementIds());
             }
-            if(list.Any<ElementId>())
+            if (list.Any<ElementId>())
             {
-                foreach(var id in list)
+                foreach (var id in list)
                 {
                     Document.Delete(id);
                 }
@@ -936,16 +936,16 @@ namespace Revit.Elements.Views
         private static void DuplicateScheduleSheetInstance(Sheet oldSheet, Sheet newSheet)
         {
             List<ElementId> list = new List<ElementId>();
-            foreach(var schedule in oldSheet.Schedules)
+            foreach (var schedule in oldSheet.Schedules)
             {
-                if(!schedule.InternalScheduleOnSheet.IsTitleblockRevisionSchedule)
+                if (!schedule.InternalScheduleOnSheet.IsTitleblockRevisionSchedule)
                 {
                     list.Add(schedule.InternalElement.Id);
                 }
             }
             if (list.Any<ElementId>())
             {
-                ElementTransformUtils.CopyElements(oldSheet.InternalViewSheet, list, newSheet.InternalViewSheet, null, null);                
+                ElementTransformUtils.CopyElements(oldSheet.InternalViewSheet, list, newSheet.InternalViewSheet, null, null);
             }
         }
 
@@ -960,8 +960,8 @@ namespace Revit.Elements.Views
             List<Revit.Elements.Views.View> viewList = new List<View>();
             List<Autodesk.Revit.DB.Element> elements = new List<Autodesk.Revit.DB.Element>();
             List<Autodesk.DesignScript.Geometry.Point> locationList = new List<Autodesk.DesignScript.Geometry.Point>();
-            foreach (var viewport in Viewports) 
-            {                
+            foreach (var viewport in Viewports)
+            {
                 if (viewport.View.InternalView.CanViewBeDuplicated(viewDuplicateOption))
                 {
                     var newViewName = prefix + viewport.View.Name + suffix;
@@ -1012,7 +1012,7 @@ namespace Revit.Elements.Views
                 .ToList();
             foreach (var s in sheets)
             {
-                if((s as ViewSheet).SheetNumber.Equals(SheetNumber))
+                if ((s as ViewSheet).SheetNumber.Equals(SheetNumber))
                 {
                     IsUnique = false;
                     break;


### PR DESCRIPTION
### List of Affected Nodes/Modules

All nodes returning a wrapped element would benefit

### Current Performance
The current implementation works perfectly fine. However the newer C# language features do provide some performance advantages here. This change does get rid of the previous public wrapper methods and might potentially cause issues if any external code was relying on them.

### Proposed Performance
we manually inline all of the one-liner wrap methods into a single pattern matching switch table.

### Dynamo Tuneup Comparison
On the standard arch. sample model collecting all elements of all categories five times over (about 125k element conversions in total), we can improve performance from 71 seconds on average down to  about 66 seconds.

![z7U8m6MpLB](https://github.com/user-attachments/assets/18b095d6-1d18-456d-af6c-b678f1f3868a)

![d5Xc26veq6](https://github.com/user-attachments/assets/c52efcac-a144-4d3e-bb6e-20522b9a93df)

This change might make the `ElementWrapper` code base less legibile.

### Checklist

- [x] There are no public function signature changes
- [x] Any public code that is no longer in use is tagged as obsolete and preserved.
- [x] The code changes have been documented
- [x] The overall behavior does not change
