### PR TITLE
Reope/performance elementbinder serialization

### DIFF
--- a/src/Libraries/RevitServices/Persistence/ElementBinder.cs
+++ b/src/Libraries/RevitServices/Persistence/ElementBinder.cs
@@ -1,23 +1,19 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Data;
+using System.IO;
 using System.Linq;
+using System.Numerics;
+using System.Text;
 using Autodesk.Revit.DB;
 using Dynamo.Engine;
 using Dynamo.Graph.Nodes;
 using Dynamo.Graph.Nodes.ZeroTouch;
 using Dynamo.Graph.Workspaces;
 using DynamoServices;
+using Newtonsoft.Json;
 using ProtoCore;
 using RevitServices.Elements;
-using Microsoft.CSharp;
-using Newtonsoft.Json;
-using System.IO;
-using System.Text;
-using Autodesk.Revit.DB.Electrical;
-using System.Text.Json;
-using System.Numerics;
-using System.Data;
-using ProtoCore.Lang;
 
 namespace RevitServices.Persistence
 {
@@ -255,14 +251,14 @@ namespace RevitServices.Persistence
 
         public static bool TryDeserialize(string json, out SerializableId id)
         {
-            //return DeSer.Instance.TryDeserializeSingle(json, out id);
-            return DeSer.TryDeserialize(json, out id);
+            return DeSer.Instance.TryDeserializeSingle(json, out id);
+            //return DeSer.TryDeserialize(json, out id);
         }
 
         public string Serialize()
         {
-            //return DeSer.Instance.SerializeSingle(this);
-            return JsonConvert.SerializeObject(this);
+            return DeSer.Instance.SerializeSingle(this);
+            //return JsonConvert.SerializeObject(this);
         }
     }
 
@@ -336,14 +332,14 @@ namespace RevitServices.Persistence
 
         public static bool TryDeserialize(string json, out MultipleSerializableId id)
         {
-            //return DeSer.Instance.TryDeserializeMulti(json, out id);
-            return DeSer.TryDeserialize(json, out id);
+            return DeSer.Instance.TryDeserializeMulti(json, out id);
+            //return DeSer.TryDeserialize(json, out id);
         }
 
         public string Serialize()
         {
-            //return DeSer.Instance.SerializeMulti(this);
-            return JsonConvert.SerializeObject(this);
+            return DeSer.Instance.SerializeMulti(this);
+            //return JsonConvert.SerializeObject(this);
         }
     }
         /// <summary>


### PR DESCRIPTION
### Purpose

Make serialization and deserialization from TraceData faster. Also makes the serialization and deserialization of SerializableId and MultipleSerializableId cleaner.

Uses a specialized de/serializer to skip creating the generic Newtonsoft.Json converter on every deserialization call.

### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] Snapshot of UI changes, if any.

### Reviewers

(FILL ME IN) Reviewer 1  (If possible, assign the Reviewer for the PR)

(FILL ME IN, optional) Any additional notes to reviewers or testers.

### FYIs

(FILL ME IN, Optional) Names of anyone else you wish to be notified of
