### PR TITLE
TransactionManager TransactionGroup strategy

### DIFF
--- a/src/DynamoRevit/DynamoRevitApp.cs
+++ b/src/DynamoRevit/DynamoRevitApp.cs
@@ -139,7 +139,7 @@ namespace Dynamo.Applications
                 SubscribeAssemblyEvents();
                 SubscribeApplicationEvents();
 
-                TransactionManager.SetupManager(new AutomaticTransactionStrategy());
+                TransactionManager.SetupManager(new AutomaticGroupingTransactionStrategy());
                 ElementBinder.IsEnabled = true;
 
                 var dynamoCmdId = RevitCommandId.LookupCommandId("ID_VISUAL_PROGRAMMING_DYNAMO");


### PR DESCRIPTION
### Purpose

This PR adds a new transaction strategy that uses TransactionGroup under the hood. It is essentially a drop in replacement for the current Automatic transaction strategy, but batches transactions into groups.

The group size can be user defined, so that the old functionality of commiting the transaction at the end of the Dynamo run remains the same. In cases where TransactionManager.TransactionTaskDone is called multiple times, the commits will happen during graph execution instead of after the graph has finished running.

The main inspiration for this PR is [this thread on the Autodesk forums](https://forums.autodesk.com/t5/revit-api-forum/committing-transactions-when-creating-a-large-number-of-elements/m-p/11607714/highlight/true#M67860)

Testing is needed to see if this has the same effect on graph execution time.

### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] Snapshot of UI changes, if any.

### Reviewers

(FILL ME IN) Reviewer 1  (If possible, assign the Reviewer for the PR)

(FILL ME IN, optional) Any additional notes to reviewers or testers.

### FYIs

(FILL ME IN, Optional) Names of anyone else you wish to be notified of
