### PR TITLE
make less id calls

### DIFF
--- a/src/Libraries/RevitNodes/Elements/AdaptiveComponent.cs
+++ b/src/Libraries/RevitNodes/Elements/AdaptiveComponent.cs
@@ -113,8 +113,7 @@ namespace Revit.Elements
             }
 
             TransactionManager.Instance.TransactionTaskDone();
-            ElementBinder.SetElementForTrace(InternalElement);
-
+            ElementBinder.SetElementForTrace(InternalElementId, InternalUniqueId);
         }
 
         /// <summary>
@@ -161,7 +160,7 @@ namespace Revit.Elements
             }
 
             TransactionManager.Instance.TransactionTaskDone();
-            ElementBinder.SetElementForTrace(InternalElement);
+            ElementBinder.SetElementForTrace(InternalElementId, InternalUniqueId);
         }
 
         #endregion
@@ -181,7 +180,7 @@ namespace Revit.Elements
                 throw new Exception(Properties.Resources.InputPointParamsMismatch);
 
             int count = placePointIds.Count;
-            for (int i = 0; i < count; i++ )
+            for (int i = 0; i < count; i++)
             {
                 var point = (Autodesk.Revit.DB.ReferencePoint)Document.GetElement(placePointIds[i]);
                 point.Position = pnts[i];
@@ -592,7 +591,7 @@ namespace Revit.Elements
 
                 ElementBinder.SetElementsForTrace(instances);
             }
-            catch(Exception e)
+            catch (Exception e)
             {
                 // Unregister the elements from the element life cycle manager and delete the elements
                 var elementManager = ElementIDLifecycleManager<long>.GetInstance();
@@ -623,7 +622,7 @@ namespace Revit.Elements
         }
 
         #endregion
-        
+
         #region Internal static constructor
 
         /// <summary>

--- a/src/Libraries/RevitNodes/Elements/Ceiling.cs
+++ b/src/Libraries/RevitNodes/Elements/Ceiling.cs
@@ -80,7 +80,7 @@ namespace Revit.Elements
 
             TransactionManager.Instance.TransactionTaskDone();
 
-            ElementBinder.CleanupAndSetElementForTrace(Document, InternalCeiling);
+            ElementBinder.CleanupAndSetElementForTrace(Document, InternalElementId, InternalUniqueId);
         }
 
         #endregion

--- a/src/Libraries/RevitNodes/Elements/CurtainSystem.cs
+++ b/src/Libraries/RevitNodes/Elements/CurtainSystem.cs
@@ -43,7 +43,7 @@ namespace Revit.Elements
         {
             SafeInit(() => InitCurtainSystem(curtainSystem), true);
         }
-      
+
         /// <summary>
         /// Private constructor
         /// </summary>
@@ -92,7 +92,7 @@ namespace Revit.Elements
 
             TransactionManager.Instance.TransactionTaskDone();
 
-            ElementBinder.CleanupAndSetElementForTrace(Document, InternalCurtainSystem);
+            ElementBinder.CleanupAndSetElementForTrace(Document, InternalElementId, InternalUniqueId);
         }
 
         #endregion

--- a/src/Libraries/RevitNodes/Elements/CurveByPoints.cs
+++ b/src/Libraries/RevitNodes/Elements/CurveByPoints.cs
@@ -101,7 +101,7 @@ namespace Revit.Elements
 
             TransactionManager.Instance.TransactionTaskDone();
 
-            ElementBinder.SetElementForTrace(this.InternalElement);
+            ElementBinder.SetElementForTrace(InternalElementId, InternalUniqueId);
         }
 
         #endregion
@@ -121,7 +121,7 @@ namespace Revit.Elements
                 throw new Exception(Properties.Resources.CurveNeedsTwoPoints);
             }
 
-            return new CurveByPoints(points.Select(x=>x.InternalReferencePoint), isReferenceLine);
+            return new CurveByPoints(points.Select(x => x.InternalReferencePoint), isReferenceLine);
         }
 
 

--- a/src/Libraries/RevitNodes/Elements/DetailCurve.cs
+++ b/src/Libraries/RevitNodes/Elements/DetailCurve.cs
@@ -55,7 +55,7 @@ namespace Revit.Elements
             // Open Transaction and get document
             Autodesk.Revit.DB.Document document = DocumentManager.Instance.CurrentDBDocument;
             TransactionManager.Instance.EnsureInTransaction(document);
-            
+
             // Get exsiting element
             var element = ElementBinder.GetElementFromTrace<Autodesk.Revit.DB.DetailCurve>(document);
 
@@ -68,18 +68,18 @@ namespace Revit.Elements
                 else
                 {
                     element = document.Create.NewDetailCurve(view, curve);
-                }                
+                }
             }
             else
             {
-                element.SetGeometryCurve(curve, true);                
+                element.SetGeometryCurve(curve, true);
             }
 
             InternalSetCurveElement(element);
 
             // Set transaction task done & element for trace
             TransactionManager.Instance.TransactionTaskDone();
-            ElementBinder.SetElementForTrace(this.InternalElement);
+            ElementBinder.SetElementForTrace(InternalElementId, InternalUniqueId);
         }
 
         #endregion
@@ -128,7 +128,7 @@ namespace Revit.Elements
         new public Autodesk.DesignScript.Geometry.Curve Curve
         {
             get
-            { 
+            {
                 return this.InternalCurveElement.GeometryCurve.ToProtoType();
             }
         }
@@ -140,7 +140,7 @@ namespace Revit.Elements
         {
             Autodesk.Revit.DB.Document document = DocumentManager.Instance.CurrentDBDocument;
             TransactionManager.Instance.EnsureInTransaction(document);
-            this.InternalCurveElement.SetGeometryCurve(curve.ToRevitType(),true);
+            this.InternalCurveElement.SetGeometryCurve(curve.ToRevitType(), true);
             TransactionManager.Instance.TransactionTaskDone();
         }
 
@@ -151,7 +151,7 @@ namespace Revit.Elements
         internal static DetailCurve FromExisting(Autodesk.Revit.DB.DetailCurve instance, bool isRevitOwned)
         {
             return new DetailCurve(instance)
-            { 
+            {
                 IsRevitOwned = isRevitOwned
             };
         }

--- a/src/Libraries/RevitNodes/Elements/Dimension.cs
+++ b/src/Libraries/RevitNodes/Elements/Dimension.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using Autodesk.DesignScript.Runtime;
@@ -121,14 +120,14 @@ namespace Revit.Elements
 
             // apply suffix
             if (this.InternalRevitElement.NumberOfSegments == 0)
-            { 
-                this.InternalRevitElement.Suffix = suffix; 
+            {
+                this.InternalRevitElement.Suffix = suffix;
             }
             else if (this.InternalRevitElement.NumberOfSegments > 1)
             {
                 foreach (DimensionSegment segment in this.InternalRevitElement.Segments)
-                { 
-                    segment.Suffix = suffix; 
+                {
+                    segment.Suffix = suffix;
                 }
             }
 
@@ -140,13 +139,13 @@ namespace Revit.Elements
             else if (this.InternalRevitElement.NumberOfSegments > 1)
             {
                 foreach (DimensionSegment segment in this.InternalRevitElement.Segments)
-                { 
-                    segment.Prefix = prefix; 
+                {
+                    segment.Prefix = prefix;
                 }
             }
 
             TransactionManager.Instance.TransactionTaskDone();
-            ElementBinder.SetElementForTrace(this.InternalElement);
+            ElementBinder.SetElementForTrace(InternalElementId, InternalUniqueId);
         }
 
         #endregion
@@ -162,7 +161,7 @@ namespace Revit.Elements
         /// <param name="suffix">Suffix</param>
         /// <param name="prefix">Prefix</param>
         /// <returns>Dimension</returns>
-        public static Dimension ByElements(Revit.Elements.Views.View view, IEnumerable<Revit.Elements.Element> referenceElements, [DefaultArgument("null")]Autodesk.DesignScript.Geometry.Line line, string suffix = "", string prefix = "")
+        public static Dimension ByElements(Revit.Elements.Views.View view, IEnumerable<Revit.Elements.Element> referenceElements, [DefaultArgument("null")] Autodesk.DesignScript.Geometry.Line line, string suffix = "", string prefix = "")
         {
             var elements = referenceElements.ToList();
 
@@ -177,7 +176,7 @@ namespace Revit.Elements
             if (line == null)
             {
                 BoundingBoxXYZ boundingBoxFirstElement = elements[0].InternalElement.get_BoundingBox(revitView);
-                if ((boundingBoxFirstElement) == null) throw new Exception(Properties.Resources.ElementCannotBeAnnotatedError); 
+                if ((boundingBoxFirstElement) == null) throw new Exception(Properties.Resources.ElementCannotBeAnnotatedError);
 
                 BoundingBoxXYZ boundingBoxLastElement = elements[elements.Count - 1].InternalElement.get_BoundingBox(revitView);
                 if ((boundingBoxLastElement) == null) throw new Exception(Properties.Resources.ElementCannotBeAnnotatedError);
@@ -211,7 +210,7 @@ namespace Revit.Elements
         /// <param name="suffix">Suffix</param>
         /// <param name="prefix">Prefix</param>
         /// <returns></returns>
-        public static Dimension ByFaces(Revit.Elements.Views.View view, IEnumerable<Autodesk.DesignScript.Geometry.Surface> referenceSurfaces, [DefaultArgument("null")]Autodesk.DesignScript.Geometry.Line line, string suffix = "", string prefix = "")
+        public static Dimension ByFaces(Revit.Elements.Views.View view, IEnumerable<Autodesk.DesignScript.Geometry.Surface> referenceSurfaces, [DefaultArgument("null")] Autodesk.DesignScript.Geometry.Line line, string suffix = "", string prefix = "")
         {
             var surfaces = referenceSurfaces.ToList();
             if (surfaces.Count < 2) throw new Exception(string.Format(Properties.Resources.NotEnoughDataError, "Surfaces"));
@@ -224,7 +223,7 @@ namespace Revit.Elements
                 throw new Exception(Properties.Resources.ViewDoesNotSupportAnnotations);
             }
 
-            if(line == null)
+            if (line == null)
             {
                 BoundingBoxXYZ boundingBoxFirstElement = surfaces[0].BoundingBox.ToRevitType();
                 if ((boundingBoxFirstElement) == null) throw new Exception(Properties.Resources.ElementCannotBeAnnotatedError);
@@ -239,7 +238,7 @@ namespace Revit.Elements
                 revitLine = (Line)line.ToRevitType(true);
 
             ReferenceArray array = new ReferenceArray();
-            foreach(var surface in surfaces)
+            foreach (var surface in surfaces)
             {
                 var reference = Revit.GeometryReferences.ElementFaceReference.TryGetFaceReference(surface);
                 array.Append(reference.InternalReference);
@@ -257,14 +256,14 @@ namespace Revit.Elements
         /// <param name="suffix">Suffix</param>
         /// <param name="prefix">Prefix</param>
         /// <returns></returns>
-        public static Dimension ByEdges(Revit.Elements.Views.View view, IEnumerable<Autodesk.DesignScript.Geometry.Curve> referenceCurves, [DefaultArgument("null")]Autodesk.DesignScript.Geometry.Line line, string suffix = "", string prefix = "")
+        public static Dimension ByEdges(Revit.Elements.Views.View view, IEnumerable<Autodesk.DesignScript.Geometry.Curve> referenceCurves, [DefaultArgument("null")] Autodesk.DesignScript.Geometry.Line line, string suffix = "", string prefix = "")
         {
             var curves = referenceCurves.ToList();
             if (curves.Count < 2) throw new Exception(string.Format(Properties.Resources.NotEnoughDataError, "Curves"));
 
             Autodesk.Revit.DB.View revitView = (Autodesk.Revit.DB.View)view.InternalElement;
             Line revitLine = null;
-            
+
             if (!view.IsAnnotationView())
             {
                 throw new Exception(Properties.Resources.ViewDoesNotSupportAnnotations);
@@ -284,7 +283,7 @@ namespace Revit.Elements
                 revitLine = (Line)line.ToRevitType(true);
 
             ReferenceArray array = new ReferenceArray();
-            foreach(var curve in curves)
+            foreach (var curve in curves)
             {
                 var reference = Revit.GeometryReferences.ElementCurveReference.TryGetCurveReference(curve);
                 array.Append(reference.InternalReference);
@@ -317,7 +316,7 @@ namespace Revit.Elements
             Line revitLine = (Line)line.ToRevitType(true);
 
             ReferenceArray array = new ReferenceArray();
-            foreach(var geo in geometries)
+            foreach (var geo in geometries)
             {
                 array.Append(geo.InternalReference);
             }
@@ -335,7 +334,7 @@ namespace Revit.Elements
         /// <param name="suffix">Suffix</param>
         /// <param name="prefix">Prefix</param>
         /// <returns></returns>
-        public static Dimension ByElementDirection(Revit.Elements.Views.View view, Revit.Elements.Element element, Autodesk.DesignScript.Geometry.Vector direction, [DefaultArgument("null")]Autodesk.DesignScript.Geometry.Line line, string suffix = "", string prefix = "")
+        public static Dimension ByElementDirection(Revit.Elements.Views.View view, Revit.Elements.Element element, Autodesk.DesignScript.Geometry.Vector direction, [DefaultArgument("null")] Autodesk.DesignScript.Geometry.Line line, string suffix = "", string prefix = "")
         {
             Autodesk.Revit.DB.View revitView = (Autodesk.Revit.DB.View)view.InternalElement;
             if (!view.IsAnnotationView())
@@ -355,7 +354,7 @@ namespace Revit.Elements
             var faces = element.InternalGeometry(false).OfType<Autodesk.Revit.DB.Solid>().SelectMany(x => x.Faces.OfType<Autodesk.Revit.DB.PlanarFace>());
             var references = faces.Select(x => x.Reference);
             Line revitLine = null;
-            
+
             foreach (var face in faces)
             {
                 var isParallel = direction.IsParallel(face.FaceNormal.ToVector());
@@ -383,7 +382,7 @@ namespace Revit.Elements
         /// <summary>
         /// Get Dimension Value
         /// </summary>
-        public IEnumerable<double> Value 
+        public IEnumerable<double> Value
         {
             get
             {
@@ -395,7 +394,7 @@ namespace Revit.Elements
                 else if (this.InternalRevitElement.NumberOfSegments > 1)
                 {
                     foreach (DimensionSegment segment in this.InternalRevitElement.Segments)
-                        data.Add(segment.Value.Value);                   
+                        data.Add(segment.Value.Value);
                 }
 
                 return data;
@@ -455,7 +454,8 @@ namespace Revit.Elements
         /// </summary>
         public IEnumerable<string> Suffix
         {
-            get {
+            get
+            {
                 List<string> data = new List<string>();
 
                 if (this.InternalRevitElement.NumberOfSegments == 0)
@@ -561,7 +561,7 @@ namespace Revit.Elements
                     .Cast<DimensionSegment>()
                     .Select(segment => segment.Above)
                     .ToList();
-            } 
+            }
         }
 
         /// <summary>
@@ -646,7 +646,7 @@ namespace Revit.Elements
         internal static Dimension FromExisting(Autodesk.Revit.DB.Dimension instance, bool isRevitOwned)
         {
             return new Dimension(instance)
-            { 
+            {
                 IsRevitOwned = isRevitOwned
             };
         }
@@ -654,7 +654,7 @@ namespace Revit.Elements
         #endregion
 
         #region Helpers
-        
+
         /// <summary>
         /// GetMidpoint from bounding box
         /// </summary>

--- a/src/Libraries/RevitNodes/Elements/DimensionType.cs
+++ b/src/Libraries/RevitNodes/Elements/DimensionType.cs
@@ -93,7 +93,7 @@ namespace Revit.Elements
 
             InternalSetElement(element);
             TransactionManager.Instance.TransactionTaskDone();
-            ElementBinder.SetElementForTrace(this.InternalElement);
+            ElementBinder.SetElementForTrace(InternalElementId, InternalUniqueId);
         }
 
         #endregion

--- a/src/Libraries/RevitNodes/Elements/DividedPath.cs
+++ b/src/Libraries/RevitNodes/Elements/DividedPath.cs
@@ -15,10 +15,10 @@ namespace Revit.Elements
     /// A Revit DividedPath
     /// </summary>
     [DynamoServices.RegisterForTrace]
-    public class DividedPath: Element
+    public class DividedPath : Element
     {
         #region Private fields
-        
+
         private static Options geometryOptions = new Options
         {
             ComputeReferences = true,
@@ -122,7 +122,7 @@ namespace Revit.Elements
             TransactionManager.Instance.TransactionTaskDone();
 
             // delete any cached ele and set this new one
-            ElementBinder.CleanupAndSetElementForTrace(Document, this.InternalElement);
+            ElementBinder.CleanupAndSetElementForTrace(Document, InternalElementId, InternalUniqueId);
         }
 
         #endregion
@@ -178,7 +178,7 @@ namespace Revit.Elements
 
             if (curveReferences.Any(x => x == null))
             {
-                throw new ArgumentNullException(String.Format("curves[{0}]",  Array.FindIndex(curveReferences, x => x == null)) );
+                throw new ArgumentNullException(String.Format("curves[{0}]", Array.FindIndex(curveReferences, x => x == null)));
             }
 
             return new DividedPath(curveReferences.Select(x => ElementCurveReference.TryGetCurveReference(x)).ToArray(), divisions);

--- a/src/Libraries/RevitNodes/Elements/DividedSurface.cs
+++ b/src/Libraries/RevitNodes/Elements/DividedSurface.cs
@@ -108,7 +108,7 @@ namespace Revit.Elements
             TransactionManager.Instance.TransactionTaskDone();
 
             // remember this new value
-            ElementBinder.SetElementForTrace(this.InternalElement);
+            ElementBinder.SetElementForTrace(InternalElementId, InternalUniqueId);
         }
 
         #endregion
@@ -190,7 +190,7 @@ namespace Revit.Elements
         {
             TransactionManager.Instance.EnsureInTransaction(Document);
 
-            if(!InternalDividedSurface.AllGridRotation.AlmostEquals(rotation, 1.0e-6))
+            if (!InternalDividedSurface.AllGridRotation.AlmostEquals(rotation, 1.0e-6))
                 InternalDividedSurface.AllGridRotation = rotation;
 
             TransactionManager.Instance.TransactionTaskDone();

--- a/src/Libraries/RevitNodes/Elements/FaceWall.cs
+++ b/src/Libraries/RevitNodes/Elements/FaceWall.cs
@@ -85,10 +85,10 @@ namespace Revit.Elements
             var wall = Autodesk.Revit.DB.FaceWall.Create(Document, wallType.Id, location, reference);
 
             InternalSetFaceWall(wall);
-            
+
             TransactionManager.Instance.TransactionTaskDone();
 
-            ElementBinder.CleanupAndSetElementForTrace(Document, InternalFaceWall);
+            ElementBinder.CleanupAndSetElementForTrace(Document, InternalElementId, InternalUniqueId);
         }
 
         #endregion

--- a/src/Libraries/RevitNodes/Elements/FamilyInstance.cs
+++ b/src/Libraries/RevitNodes/Elements/FamilyInstance.cs
@@ -120,7 +120,7 @@ namespace Revit.Elements
 
             TransactionManager.Instance.TransactionTaskDone();
 
-            ElementBinder.SetElementForTrace(InternalElement);
+            ElementBinder.SetElementForTrace(InternalElementId, InternalUniqueId);
         }
 
         /// <summary>
@@ -156,7 +156,7 @@ namespace Revit.Elements
 
             TransactionManager.Instance.TransactionTaskDone();
 
-            ElementBinder.SetElementForTrace(InternalElement);
+            ElementBinder.SetElementForTrace(InternalElementId, InternalUniqueId);
         }
 
         private void InitFamilyInstance(Autodesk.Revit.DB.FamilySymbol fs, Autodesk.Revit.DB.Reference reference, Autodesk.Revit.DB.Line pos)
@@ -181,15 +181,15 @@ namespace Revit.Elements
             if (!fs.IsActive)
                 fs.Activate();
 
-            var fi = Document.IsFamilyDocument 
-                ? Document.FamilyCreate.NewFamilyInstance(reference, pos, fs) 
+            var fi = Document.IsFamilyDocument
+                ? Document.FamilyCreate.NewFamilyInstance(reference, pos, fs)
                 : Document.Create.NewFamilyInstance(reference, pos, fs);
 
             InternalSetFamilyInstance(fi);
 
             TransactionManager.Instance.TransactionTaskDone();
 
-            ElementBinder.SetElementForTrace(InternalElement);
+            ElementBinder.SetElementForTrace(InternalElementId, InternalUniqueId);
         }
 
         private void InitFamilyInstance(Autodesk.Revit.DB.FamilySymbol fs, Autodesk.Revit.DB.Reference reference, Autodesk.Revit.DB.XYZ location,
@@ -215,15 +215,15 @@ namespace Revit.Elements
             if (!fs.IsActive)
                 fs.Activate();
 
-            var fi = Document.IsFamilyDocument 
-                ? Document.FamilyCreate.NewFamilyInstance(reference,  location, referenceDirection, fs) 
+            var fi = Document.IsFamilyDocument
+                ? Document.FamilyCreate.NewFamilyInstance(reference, location, referenceDirection, fs)
                 : Document.Create.NewFamilyInstance(reference, location, referenceDirection, fs);
 
             InternalSetFamilyInstance(fi);
 
             TransactionManager.Instance.TransactionTaskDone();
 
-            ElementBinder.SetElementForTrace(InternalElement);
+            ElementBinder.SetElementForTrace(InternalElementId, InternalUniqueId);
         }
 
         private void InitFamilyInstance(Autodesk.Revit.DB.FamilySymbol fs, Autodesk.Revit.DB.Element host, Autodesk.Revit.DB.XYZ location)
@@ -256,7 +256,7 @@ namespace Revit.Elements
 
             TransactionManager.Instance.TransactionTaskDone();
 
-            ElementBinder.SetElementForTrace(InternalElement);
+            ElementBinder.SetElementForTrace(InternalElementId, InternalUniqueId);
         }
         #endregion
 
@@ -329,7 +329,7 @@ namespace Revit.Elements
         {
             get
             {
-                return InternalFamilyInstance.IsValidObject ? 
+                return InternalFamilyInstance.IsValidObject ?
                     InternalFamilyInstance.FacingOrientation.ToVector() : null;
             }
         }
@@ -377,8 +377,8 @@ namespace Revit.Elements
             if (familyType == null)
             {
                 throw new ArgumentNullException("familyType");
-            } 
-            
+            }
+
             if (point == null)
             {
                 throw new ArgumentNullException("point");
@@ -413,7 +413,7 @@ namespace Revit.Elements
             }
             var reference = ElementFaceReference.TryGetFaceReference(face);
 
-            return new FamilyInstance(familyType.InternalFamilySymbol, reference.InternalReference, (Autodesk.Revit.DB.Line) line.ToRevitType());
+            return new FamilyInstance(familyType.InternalFamilySymbol, reference.InternalReference, (Autodesk.Revit.DB.Line)line.ToRevitType());
         }
 
         /// <summary>
@@ -427,7 +427,7 @@ namespace Revit.Elements
         /// <param name="location">Point on the face where the instance is to be placed</param>
         /// <param name="referenceDirection">A vector that defines the direction of placement of the family instance</param>
         /// <returns>FamilyInstance</returns>
-        public static FamilyInstance ByFace(FamilyType familyType, Surface face, Point location, 
+        public static FamilyInstance ByFace(FamilyType familyType, Surface face, Point location,
             Vector referenceDirection)
         {
             if (familyType == null)
@@ -448,7 +448,7 @@ namespace Revit.Elements
             }
             var reference = ElementFaceReference.TryGetFaceReference(face);
 
-            return new FamilyInstance(familyType.InternalFamilySymbol, reference.InternalReference, 
+            return new FamilyInstance(familyType.InternalFamilySymbol, reference.InternalReference,
                 location.ToXyz(), referenceDirection.ToXyz());
         }
 
@@ -594,10 +594,10 @@ namespace Revit.Elements
         /// <summary>
         /// Gets the family of this family instance
         /// </summary>
-        public Family GetFamily 
-        { 
-            get 
-            { 
+        public Family GetFamily
+        {
+            get
+            {
                 return Family.FromExisting(this.InternalFamilyInstance.Symbol.Family, true);
             }
         }
@@ -613,7 +613,7 @@ namespace Revit.Elements
             get { return base.Type; }
         }
 
-        
+
 
         /// <summary>
         /// Set the Euler angle of the family instance around its local Z-axis.

--- a/src/Libraries/RevitNodes/Elements/FilledRegion.cs
+++ b/src/Libraries/RevitNodes/Elements/FilledRegion.cs
@@ -104,12 +104,13 @@ namespace Revit.Elements
             if (null != region)
                 DocumentManager.Instance.DeleteElement(new ElementUUID(region.UniqueId));
 
-            region = Autodesk.Revit.DB.FilledRegion.Create(document, typeId, view.Id, boundary.ToList()); 
+            region = Autodesk.Revit.DB.FilledRegion.Create(document, typeId, view.Id, boundary.ToList());
 
             InternalSetElement(region);
 
             TransactionManager.Instance.TransactionTaskDone();
-            ElementBinder.SetElementForTrace(this.InternalElement);
+
+            ElementBinder.SetElementForTrace(InternalElementId, InternalUniqueId);
         }
 
         #endregion

--- a/src/Libraries/RevitNodes/Elements/Floor.cs
+++ b/src/Libraries/RevitNodes/Elements/Floor.cs
@@ -48,7 +48,7 @@ namespace Revit.Elements
         {
             SafeInit(() => InitFloor(floor), true);
         }
-      
+
         /// <summary>
         /// Private constructor
         /// </summary>
@@ -75,12 +75,12 @@ namespace Revit.Elements
         private void InitFloor(List<CurveLoop> profiles, Autodesk.Revit.DB.FloorType floorType, Autodesk.Revit.DB.Level level, double offset = 0)
         {
             TransactionManager.Instance.EnsureInTransaction(Document);
-            
+
             // we assume the floor is not structural here, this may be a bad assumption
             Autodesk.Revit.DB.Floor floor = Autodesk.Revit.DB.Floor.Create(Document, profiles, floorType.Id, level.Id);
             var param = floor.get_Parameter(BuiltInParameter.FLOOR_HEIGHTABOVELEVEL_PARAM);
-            
-            if(param !=null && Math.Abs(offset - 0) > Tolerance)
+
+            if (param != null && Math.Abs(offset - 0) > Tolerance)
             {
                 InternalUtilities.ElementUtils.SetParameterValue(param, offset);
             }
@@ -88,7 +88,7 @@ namespace Revit.Elements
 
             TransactionManager.Instance.TransactionTaskDone();
 
-            ElementBinder.CleanupAndSetElementForTrace(Document, InternalFloor);
+            ElementBinder.CleanupAndSetElementForTrace(Document, InternalElementId, InternalUniqueId);
         }
 
         #endregion
@@ -149,7 +149,7 @@ namespace Revit.Elements
                 throw new ArgumentNullException("floorType");
             }
 
-            if ( level == null )
+            if (level == null)
             {
                 throw new ArgumentNullException("level");
             }
@@ -187,7 +187,7 @@ namespace Revit.Elements
         /// </summary>
         public IEnumerable<Pt> Points
         {
-            get 
+            get
             {
                 if (this.InternalFloor.GetSlabShapeEditor() == null)
                 {
@@ -198,7 +198,7 @@ namespace Revit.Elements
                 this.InternalFloor.GetSlabShapeEditor().Enable();
                 TransactionManager.Instance.TransactionTaskDone();
 
-                List<Pt> points = new List<Pt>();              
+                List<Pt> points = new List<Pt>();
                 foreach (SlabShapeVertex v in this.InternalFloor.GetSlabShapeEditor().SlabShapeVertices)
                 {
                     points.Add(v.Position.ToPoint());

--- a/src/Libraries/RevitNodes/Elements/Form.cs
+++ b/src/Libraries/RevitNodes/Elements/Form.cs
@@ -81,7 +81,7 @@ namespace Revit.Elements
 
             TransactionManager.Instance.TransactionTaskDone();
 
-            ElementBinder.CleanupAndSetElementForTrace(Document, this.InternalElement);
+            ElementBinder.CleanupAndSetElementForTrace(Document, InternalElementId, InternalUniqueId);
         }
 
         #endregion

--- a/src/Libraries/RevitNodes/Elements/FreeForm.cs
+++ b/src/Libraries/RevitNodes/Elements/FreeForm.cs
@@ -101,7 +101,7 @@ namespace Revit.Elements
 
             TransactionManager.Instance.TransactionTaskDone();
 
-            ElementBinder.SetElementForTrace(this.InternalElement);
+            ElementBinder.SetElementForTrace(InternalElementId, InternalUniqueId);
         }
 
         #endregion

--- a/src/Libraries/RevitNodes/Elements/GlobalParameter.cs
+++ b/src/Libraries/RevitNodes/Elements/GlobalParameter.cs
@@ -4,7 +4,6 @@ using DynamoServices;
 using Revit.GeometryConversion;
 using RevitServices.Persistence;
 using RevitServices.Transactions;
-using Dynamo.Graph.Nodes;
 
 namespace Revit.Elements
 {
@@ -94,7 +93,7 @@ namespace Revit.Elements
                 TransactionManager.Instance.TransactionTaskDone();
             }
 
-            ElementBinder.CleanupAndSetElementForTrace(Document, InternalGlobalParameter);
+            ElementBinder.CleanupAndSetElementForTrace(Document, InternalElementId, InternalUniqueId);
         }
 
 
@@ -139,7 +138,7 @@ namespace Revit.Elements
                     return GlobalParameter.FromExisting(global, true);
                 }
             }
-            
+
             return null;
         }
 
@@ -218,7 +217,7 @@ namespace Revit.Elements
                 // get document and open transaction
                 Autodesk.Revit.DB.Document document = Application.Document.Current.InternalDocument;
                 TransactionManager.Instance.EnsureInTransaction(document);
-                
+
                 if (value == null)
                 {
                     parameter.InternalGlobalParameter.SetValue(
@@ -260,7 +259,7 @@ namespace Revit.Elements
                 TransactionManager.Instance.EnsureInTransaction(document);
 
                 Autodesk.Revit.DB.ElementId id = new Autodesk.Revit.DB.ElementId(elementId);
-                parameter.InternalGlobalParameter.SetValue(new Autodesk.Revit.DB.ElementIdParameterValue(id));              
+                parameter.InternalGlobalParameter.SetValue(new Autodesk.Revit.DB.ElementIdParameterValue(id));
 
                 TransactionManager.Instance.TransactionTaskDone();
             }
@@ -306,7 +305,7 @@ namespace Revit.Elements
         #endregion
 
         #region Public static constructors
-        
+
         /// <summary>
         /// Create a new Global Parameter by Name and Type
         /// </summary>

--- a/src/Libraries/RevitNodes/Elements/Grid.cs
+++ b/src/Libraries/RevitNodes/Elements/Grid.cs
@@ -92,7 +92,7 @@ namespace Revit.Elements
 
             TransactionManager.Instance.TransactionTaskDone();
 
-            ElementBinder.CleanupAndSetElementForTrace(Document, this.InternalElement);
+            ElementBinder.CleanupAndSetElementForTrace(Document, InternalElementId, InternalUniqueId);
         }
 
         /// <summary>
@@ -109,7 +109,7 @@ namespace Revit.Elements
 
             TransactionManager.Instance.TransactionTaskDone();
 
-            ElementBinder.CleanupAndSetElementForTrace(Document, this.InternalElement);
+            ElementBinder.CleanupAndSetElementForTrace(Document, InternalElementId, InternalUniqueId);
         }
 
         #endregion
@@ -177,7 +177,7 @@ namespace Revit.Elements
                 throw new ArgumentNullException("line");
             }
 
-            return new Grid( (Autodesk.Revit.DB.Line) line.ToRevitType());
+            return new Grid((Autodesk.Revit.DB.Line)line.ToRevitType());
         }
 
         /// <summary>
@@ -225,7 +225,7 @@ namespace Revit.Elements
                 throw new ArgumentNullException("arc");
             }
 
-            return new Grid( (Autodesk.Revit.DB.Arc) arc.ToRevitType() );
+            return new Grid((Autodesk.Revit.DB.Arc)arc.ToRevitType());
         }
 
         #endregion

--- a/src/Libraries/RevitNodes/Elements/ImportInstance.cs
+++ b/src/Libraries/RevitNodes/Elements/ImportInstance.cs
@@ -52,7 +52,7 @@ namespace Revit.Elements
         /// <param name="element"></param>
         private ImportInstance(Autodesk.Revit.DB.ImportInstance element)
         {
-            SafeInit(() => InternalSetImportInstance(element),true);
+            SafeInit(() => InternalSetImportInstance(element), true);
         }
 
         #endregion
@@ -94,7 +94,7 @@ namespace Revit.Elements
 
             TransactionManager.Instance.TransactionTaskDone();
 
-            ElementBinder.SetElementForTrace(importInstance);
+            ElementBinder.SetElementForTrace(InternalElementId, InternalUniqueId);
         }
 
         private void InternalUnpinAndTranslateImportInstance(Autodesk.Revit.DB.XYZ translation)
@@ -183,9 +183,9 @@ namespace Revit.Elements
             {
                 throw new ArgumentNullException("view");
             }
-            
+
             var translation = Vector.ByCoordinates(0, 0, 0);
-            
+
             var exported_fn = CreateSATFile(geometries, ref translation);
 
             return new ImportInstance(exported_fn, translation.ToXyz(), view);
@@ -219,7 +219,7 @@ namespace Revit.Elements
         }
 
         #region Helper methods
-        
+
         /// <summary>
         /// This method contains workarounds for increasing the robustness of input geometry
         /// </summary>
@@ -254,7 +254,7 @@ namespace Revit.Elements
             var bb = Autodesk.DesignScript.Geometry.BoundingBox.ByGeometry(geometries);
 
             // get center of bbox
-            var trans = ((bb.MinPoint.ToXyz() + bb.MaxPoint.ToXyz())/2).ToVector().Reverse();
+            var trans = ((bb.MinPoint.ToXyz() + bb.MaxPoint.ToXyz()) / 2).ToVector().Reverse();
             bb.Dispose();
 
             // translate all geom so that it is centered by bb

--- a/src/Libraries/RevitNodes/Elements/ModelCurve.cs
+++ b/src/Libraries/RevitNodes/Elements/ModelCurve.cs
@@ -121,8 +121,7 @@ namespace Revit.Elements
 
             TransactionManager.Instance.TransactionTaskDone();
 
-            ElementBinder.SetElementForTrace(this.InternalElement);
-
+            ElementBinder.SetElementForTrace(InternalElementId, InternalUniqueId);
         }
 
         #endregion
@@ -201,7 +200,7 @@ namespace Revit.Elements
             if (!Document.IsFamilyDocument)
                 throw new Exception(Properties.Resources.ReferenceCurveCreationFailure);
 
-           return new ModelCurve(ExtractLegalRevitCurve(curve), true);
+            return new ModelCurve(ExtractLegalRevitCurve(curve), true);
         }
 
         #endregion

--- a/src/Libraries/RevitNodes/Elements/ModelText.cs
+++ b/src/Libraries/RevitNodes/Elements/ModelText.cs
@@ -91,7 +91,7 @@ namespace Revit.Elements
         /// <param name="yCoordinateInPlane"></param>
         /// <param name="textDepth"></param>
         /// <param name="modelTextType"></param>
-        private void InitModelText(string text, Autodesk.Revit.DB.SketchPlane sketchPlane, 
+        private void InitModelText(string text, Autodesk.Revit.DB.SketchPlane sketchPlane,
             double xCoordinateInPlane, double yCoordinateInPlane, double textDepth,
             Autodesk.Revit.DB.ModelTextType modelTextType)
         {
@@ -125,7 +125,7 @@ namespace Revit.Elements
 
             TransactionManager.Instance.TransactionTaskDone();
 
-            ElementBinder.SetElementForTrace(this.InternalElement);
+            ElementBinder.SetElementForTrace(InternalElementId, InternalUniqueId);
         }
 
         #endregion
@@ -140,7 +140,7 @@ namespace Revit.Elements
         {
             TransactionManager.Instance.EnsureInTransaction(Document);
 
-            if(!InternalModelText.Depth.AlmostEquals(depth, 1.0e-6))
+            if (!InternalModelText.Depth.AlmostEquals(depth, 1.0e-6))
                 InternalModelText.Depth = depth;
 
             TransactionManager.Instance.TransactionTaskDone();
@@ -154,7 +154,7 @@ namespace Revit.Elements
         {
             TransactionManager.Instance.EnsureInTransaction(Document);
 
-            if(InternalModelText.Text != text)
+            if (InternalModelText.Text != text)
                 InternalModelText.Text = text;
 
             TransactionManager.Instance.TransactionTaskDone();
@@ -168,7 +168,7 @@ namespace Revit.Elements
         {
             TransactionManager.Instance.EnsureInTransaction(Document);
 
-            if(InternalModelText.ModelTextType.UniqueId != modelTextType.UniqueId)
+            if (InternalModelText.ModelTextType.UniqueId != modelTextType.UniqueId)
                 InternalModelText.ModelTextType = modelTextType;
 
             TransactionManager.Instance.TransactionTaskDone();
@@ -201,7 +201,7 @@ namespace Revit.Elements
         /// <returns></returns>
         private static bool PositionUnchanged(Autodesk.Revit.DB.ModelText oldModelText, Autodesk.Revit.DB.SketchPlane newSketchPlane, double xCoordinateInPlane, double yCoordinateInPlane)
         {
-           
+
             var oldPosition = ((LocationPoint)oldModelText.Location).Point;
 
             var plane = newSketchPlane.GetPlane();
@@ -210,7 +210,7 @@ namespace Revit.Elements
             return (oldPosition.IsAlmostEqualTo(newPosition));
 
         }
-        
+
         /// <summary>
         /// Create a ModelText element in the current Family Document
         /// </summary>
@@ -228,9 +228,9 @@ namespace Revit.Elements
             // obtain the position of the ModelText element in the plane of the sketchPlane
             var plane = sketchPlane.GetPlane();
             var pos = plane.Origin + plane.XVec * xCoordinateInPlane + plane.YVec * yCoordinateInPlane;
-                
+
             // create the modeltext
-            var mt = Document.FamilyCreate.NewModelText(text, modelTextType, sketchPlane, pos, HorizontalAlign.Left, textDepth);         
+            var mt = Document.FamilyCreate.NewModelText(text, modelTextType, sketchPlane, pos, HorizontalAlign.Left, textDepth);
 
             TransactionManager.Instance.TransactionTaskDone();
 
@@ -283,7 +283,7 @@ namespace Revit.Elements
         /// <param name="textDepth"></param>
         /// <param name="modelTextType"></param>
         /// <returns></returns>
-        public static ModelText ByTextSketchPlaneAndPosition(string text, SketchPlane sketchPlane, double xCoordinateInPlane, double yCoordinateInPlane, double textDepth, ModelTextType modelTextType )
+        public static ModelText ByTextSketchPlaneAndPosition(string text, SketchPlane sketchPlane, double xCoordinateInPlane, double yCoordinateInPlane, double textDepth, ModelTextType modelTextType)
         {
             if (!Document.IsFamilyDocument)
             {
@@ -305,10 +305,10 @@ namespace Revit.Elements
                 throw new ArgumentNullException("modelTextType");
             }
 
-            return new ModelText(text, sketchPlane.InternalSketchPlane, 
+            return new ModelText(text, sketchPlane.InternalSketchPlane,
                 xCoordinateInPlane * UnitConverter.DynamoToHostFactor(SpecTypeId.Length),
                 yCoordinateInPlane * UnitConverter.DynamoToHostFactor(SpecTypeId.Length),
-                textDepth * UnitConverter.DynamoToHostFactor(SpecTypeId.Length), 
+                textDepth * UnitConverter.DynamoToHostFactor(SpecTypeId.Length),
                 modelTextType.InternalModelTextType);
         }
 

--- a/src/Libraries/RevitNodes/Elements/ReferencePlane.cs
+++ b/src/Libraries/RevitNodes/Elements/ReferencePlane.cs
@@ -46,7 +46,7 @@ namespace Revit.Elements
         /// Internal reference plane
         /// </summary>
         /// <param name="referencePlane"></param>
-        private ReferencePlane( Autodesk.Revit.DB.ReferencePlane referencePlane)
+        private ReferencePlane(Autodesk.Revit.DB.ReferencePlane referencePlane)
         {
             SafeInit(() => InitReferencePlane(referencePlane), true);
         }
@@ -58,7 +58,7 @@ namespace Revit.Elements
         /// <param name="freeEnd"></param>
         /// <param name="normal"></param>
         /// <param name="view"></param>
-        private ReferencePlane(XYZ bubbleEnd, XYZ freeEnd, XYZ normal, View view )
+        private ReferencePlane(XYZ bubbleEnd, XYZ freeEnd, XYZ normal, View view)
         {
             SafeInit(() => InitReferencePlane(bubbleEnd, freeEnd, normal, view));
         }
@@ -128,7 +128,7 @@ namespace Revit.Elements
 
             TransactionManager.Instance.TransactionTaskDone();
 
-            ElementBinder.SetElementForTrace(InternalReferencePlane);
+            ElementBinder.SetElementForTrace(InternalElementId, InternalUniqueId);
         }
 
         #endregion
@@ -224,7 +224,7 @@ namespace Revit.Elements
         /// </summary>
         /// <param name="line">The line where the bubble wil be located at the start</param>
         /// <returns></returns>
-        public static ReferencePlane ByLine( Line line )
+        public static ReferencePlane ByLine(Line line)
         {
             if (line == null)
             {
@@ -235,10 +235,10 @@ namespace Revit.Elements
             var end = line.EndPoint.ToXyz();
             var norm = (end - start).GetPerpendicular();
 
-            return new ReferencePlane(  start, 
+            return new ReferencePlane(start,
                                         end,
-                                        norm, 
-                                        Document.ActiveView );
+                                        norm,
+                                        Document.ActiveView);
         }
 
         /// <summary>
@@ -247,7 +247,7 @@ namespace Revit.Elements
         /// <param name="start">The location where the bubble will be located</param>
         /// <param name="end">The other end</param>
         /// <returns></returns>
-        public static ReferencePlane ByStartPointEndPoint( Point start, Point end )
+        public static ReferencePlane ByStartPointEndPoint(Point start, Point end)
         {
             if (start == null)
             {
@@ -259,7 +259,7 @@ namespace Revit.Elements
                 throw new ArgumentNullException("end");
             }
 
-            return new ReferencePlane(  start.ToXyz(), 
+            return new ReferencePlane(start.ToXyz(),
                                         end.ToXyz(),
                                         (end.ToXyz() - start.ToXyz()).GetPerpendicular(),
                                         Document.ActiveView);

--- a/src/Libraries/RevitNodes/Elements/ReferencePoint.cs
+++ b/src/Libraries/RevitNodes/Elements/ReferencePoint.cs
@@ -127,7 +127,7 @@ namespace Revit.Elements
 
             TransactionManager.Instance.TransactionTaskDone();
 
-            ElementBinder.SetElementForTrace(InternalElement);
+            ElementBinder.SetElementForTrace(InternalElementId, InternalUniqueId);
 
             // otherwise the point value is invalid for downstream requests
             DocumentManager.Regenerate();
@@ -164,7 +164,7 @@ namespace Revit.Elements
 
             TransactionManager.Instance.TransactionTaskDone();
 
-            ElementBinder.SetElementForTrace(InternalElement);
+            ElementBinder.SetElementForTrace(InternalElementId, InternalUniqueId);
         }
 
         /// <summary>
@@ -192,7 +192,7 @@ namespace Revit.Elements
 
             TransactionManager.Instance.TransactionTaskDone();
 
-            ElementBinder.SetElementForTrace(InternalElement);
+            ElementBinder.SetElementForTrace(InternalElementId, InternalUniqueId);
         }
 
         #endregion
@@ -203,7 +203,7 @@ namespace Revit.Elements
         {
             TransactionManager.Instance.EnsureInTransaction(Document);
 
-            if(!InternalReferencePoint.Position.IsAlmostEqualTo(xyz))
+            if (!InternalReferencePoint.Position.IsAlmostEqualTo(xyz))
                 InternalReferencePoint.Position = xyz;
 
             TransactionManager.Instance.TransactionTaskDone();
@@ -223,7 +223,7 @@ namespace Revit.Elements
             PointOnCurveMeasurementType measurementType, PointOnCurveMeasureFrom measureFrom)
         {
             TransactionManager.Instance.EnsureInTransaction(Document);
-            
+
             var plc = new PointLocationOnCurve(measurementType, parameter, measureFrom);
             var edgePoint = Document.Application.Create.NewPointOnEdge(curveReference, plc);
             InternalReferencePoint.SetPointElementReference(edgePoint);
@@ -387,7 +387,7 @@ namespace Revit.Elements
                 throw new ArgumentNullException("direction");
             }
 
-            var pt = (Point) basePoint.Translate(direction.Scale(distance));
+            var pt = (Point)basePoint.Translate(direction.Scale(distance));
 
             return new ReferencePoint(pt.ToXyz());
 

--- a/src/Libraries/RevitNodes/Elements/Revision.cs
+++ b/src/Libraries/RevitNodes/Elements/Revision.cs
@@ -106,10 +106,10 @@ namespace Revit.Elements
             var RevisionElem = ElementBinder.GetElementFromTrace<Autodesk.Revit.DB.Revision>(document);
 
             if (RevisionElem == null)
-            { 
-                RevisionElem = Autodesk.Revit.DB.Revision.Create(document); 
+            {
+                RevisionElem = Autodesk.Revit.DB.Revision.Create(document);
             }
-            
+
             // Apply properties
             if (RevisionElem.Visibility != visibility)
             {
@@ -151,7 +151,8 @@ namespace Revit.Elements
 
             // commit transaction and set element for trace
             TransactionManager.Instance.TransactionTaskDone();
-            ElementBinder.SetElementForTrace(this.InternalElement);
+
+            ElementBinder.SetElementForTrace(InternalElementId, InternalUniqueId);
         }
 
         private static ElementId GetRevisionNumberingSequence(RevisionNumberType numberType)
@@ -173,7 +174,7 @@ namespace Revit.Elements
                     break;
                 }
             }
-            if(revisionNumberingSequenceId == ElementId.InvalidElementId)
+            if (revisionNumberingSequenceId == ElementId.InvalidElementId)
             {
                 RevisionNumberingSequence revisionNumberingSequence;
                 switch (numberType)
@@ -187,9 +188,9 @@ namespace Revit.Elements
                         revisionNumberingSequenceId = revisionNumberingSequence.Id;
                         break;
                 }
-                
+
             }
-            
+
             return revisionNumberingSequenceId;
         }
 
@@ -209,11 +210,11 @@ namespace Revit.Elements
         /// <param name="issuedTo">Issued to</param>
         /// <param name="numberType">Number type</param>
         /// <returns></returns>
-        public static Revision ByName(string name, string revDate, string description, bool issued, string issuedBy, string issuedTo, string visibility = "",string numberType = "")
+        public static Revision ByName(string name, string revDate, string description, bool issued, string issuedBy, string issuedTo, string visibility = "", string numberType = "")
         {
             RevisionVisibility revVisibility = RevisionVisibility.CloudAndTagVisible;
             if (!Enum.TryParse<RevisionVisibility>(visibility, out revVisibility)) revVisibility = RevisionVisibility.CloudAndTagVisible;
-            
+
             RevisionNumberType revNumberType = RevisionNumberType.Alphanumeric;
             if (!Enum.TryParse<RevisionNumberType>(numberType, out revNumberType)) revNumberType = RevisionNumberType.Alphanumeric;
 
@@ -221,7 +222,7 @@ namespace Revit.Elements
         }
 
         #endregion
-        
+
         #region Properties
 
         /// <summary>
@@ -314,7 +315,7 @@ namespace Revit.Elements
         internal static Revision FromExisting(Autodesk.Revit.DB.Revision instance, bool isRevitOwned)
         {
             return new Revision(instance)
-            { 
+            {
                 IsRevitOwned = isRevitOwned
             };
         }

--- a/src/Libraries/RevitNodes/Elements/RevisionCloud.cs
+++ b/src/Libraries/RevitNodes/Elements/RevisionCloud.cs
@@ -107,8 +107,8 @@ namespace Revit.Elements
 
             // commit transaction and set element for trace
             TransactionManager.Instance.TransactionTaskDone();
-            ElementBinder.SetElementForTrace(this.InternalElement);
 
+            ElementBinder.SetElementForTrace(InternalElementId, InternalUniqueId);
         }
 
         #endregion
@@ -149,7 +149,8 @@ namespace Revit.Elements
         /// </summary>
         public Revision Revision
         {
-            get {
+            get
+            {
                 Autodesk.Revit.DB.Document document = DocumentManager.Instance.CurrentDBDocument;
                 Autodesk.Revit.DB.Revision revision = (Autodesk.Revit.DB.Revision)document.GetElement(this.InternalRevitElement.RevisionId);
                 return Revision.FromExisting(revision, true);
@@ -162,7 +163,7 @@ namespace Revit.Elements
         /// Get Revision cloud's curves
         /// </summary>
         new public IEnumerable<Autodesk.DesignScript.Geometry.Curve> Curves
-        { 
+        {
             get
             {
                 List<Autodesk.DesignScript.Geometry.Curve> curves = new List<Autodesk.DesignScript.Geometry.Curve>();

--- a/src/Libraries/RevitNodes/Elements/Roof.cs
+++ b/src/Libraries/RevitNodes/Elements/Roof.cs
@@ -46,7 +46,7 @@ namespace Revit.Elements
         {
             SafeInit(() => InitRoof(roof), true);
         }
-      
+
         /// <summary>
         /// Private constructor
         /// </summary>
@@ -93,7 +93,7 @@ namespace Revit.Elements
 
             TransactionManager.Instance.TransactionTaskDone();
 
-            ElementBinder.CleanupAndSetElementForTrace(Document, InternalRoof);
+            ElementBinder.CleanupAndSetElementForTrace(Document, InternalElementId, InternalUniqueId);
         }
 
         /// <summary>
@@ -119,7 +119,7 @@ namespace Revit.Elements
 
             TransactionManager.Instance.TransactionTaskDone();
 
-            ElementBinder.CleanupAndSetElementForTrace(Document, InternalRoof);
+            ElementBinder.CleanupAndSetElementForTrace(Document, InternalElementId, InternalUniqueId);
         }
 
         #endregion
@@ -159,12 +159,13 @@ namespace Revit.Elements
             }
 
             var ca = new CurveArray();
-            polycurve.Curves().ForEach(x => {
+            polycurve.Curves().ForEach(x =>
+            {
                 ca.Append(x.ToRevitType());
                 x.Dispose();
-                });
-            
-            var roof = new Roof(ca, level.InternalLevel,roofType.InternalRoofType);
+            });
+
+            var roof = new Roof(ca, level.InternalLevel, roofType.InternalRoofType);
             DocumentManager.Regenerate();
             return roof;
         }
@@ -188,10 +189,11 @@ namespace Revit.Elements
             }
 
             var ca = new CurveArray();
-            outline.Curves().ForEach(x => {
+            outline.Curves().ForEach(x =>
+            {
                 ca.Append(x.ToRevitType());
                 x.Dispose();
-                });
+            });
 
             var roof = new Roof(ca, plane.InternalReferencePlane, level.InternalLevel, roofType.InternalRoofType, extrusionStart, extrusionEnd);
             DocumentManager.Regenerate();
@@ -208,7 +210,7 @@ namespace Revit.Elements
         /// </summary>
         public IEnumerable<Pt> Points
         {
-            get 
+            get
             {
                 if (this.InternalRoof.GetSlabShapeEditor() == null)
                 {

--- a/src/Libraries/RevitNodes/Elements/Room.cs
+++ b/src/Libraries/RevitNodes/Elements/Room.cs
@@ -33,7 +33,7 @@ namespace Revit.Elements
         {
             get { return InternalRevitElement; }
         }
-       
+
         #endregion
 
         #region Private constructors
@@ -101,12 +101,12 @@ namespace Revit.Elements
 
             // Apply name and number if set
             if (!string.IsNullOrEmpty(name))
-            { 
+            {
                 RoomElem.Name = name;
             }
 
             if (!string.IsNullOrEmpty(number))
-            { 
+            {
                 RoomElem.Number = number;
             }
 
@@ -115,7 +115,7 @@ namespace Revit.Elements
             // Commit transaction
             TransactionManager.Instance.TransactionTaskDone();
 
-            ElementBinder.SetElementForTrace(this.InternalElement);
+            ElementBinder.SetElementForTrace(InternalElementId, InternalUniqueId);
         }
 
         #endregion      
@@ -187,7 +187,7 @@ namespace Revit.Elements
         /// </summary>
         new public string Name
         {
-            get{ return this.InternalRevitElement.get_Parameter(BuiltInParameter.ROOM_NAME).AsString();  }           
+            get { return this.InternalRevitElement.get_Parameter(BuiltInParameter.ROOM_NAME).AsString(); }
         }
 
         /// <summary>
@@ -205,7 +205,7 @@ namespace Revit.Elements
         {
             get
             {
-               return this.InternalRevitElement.Area * UnitConverter.HostToDynamoFactor(SpecTypeId.Area);
+                return this.InternalRevitElement.Area * UnitConverter.HostToDynamoFactor(SpecTypeId.Area);
             }
         }
 
@@ -329,7 +329,7 @@ namespace Revit.Elements
         internal static Room FromExisting(Autodesk.Revit.DB.Architecture.Room instance, bool isRevitOwned)
         {
             return new Room(instance)
-            { 
+            {
                 IsRevitOwned = isRevitOwned
             };
         }

--- a/src/Libraries/RevitNodes/Elements/ScheduleOnSheet.cs
+++ b/src/Libraries/RevitNodes/Elements/ScheduleOnSheet.cs
@@ -1,9 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Autodesk.DesignScript.Geometry;
 using Autodesk.Revit.DB;
 using Revit.Elements.Views;
 using Revit.GeometryConversion;
@@ -84,13 +80,13 @@ namespace Revit.Elements
 
             var scheduleOnSheetElement = ElementBinder.GetElementFromTrace<Autodesk.Revit.DB.ScheduleSheetInstance>(Document);
 
-            scheduleOnSheetElement = Autodesk.Revit.DB.ScheduleSheetInstance.Create(Document, sheetId, scheduleViewId, scheduleLocation);            
+            scheduleOnSheetElement = Autodesk.Revit.DB.ScheduleSheetInstance.Create(Document, sheetId, scheduleViewId, scheduleLocation);
 
             InternalSetScheduleOnSheet(scheduleOnSheetElement);
 
             TransactionManager.Instance.TransactionTaskDone();
 
-            ElementBinder.CleanupAndSetElementForTrace(Document, this.InternalElement);
+            ElementBinder.CleanupAndSetElementForTrace(Document, InternalElementId, InternalUniqueId);
         }
 
         #endregion
@@ -185,7 +181,7 @@ namespace Revit.Elements
             {
                 throw new ArgumentNullException("location");
             }
-            if(IsScheduleEmpty(scheduleView.InternalViewSchedule))
+            if (IsScheduleEmpty(scheduleView.InternalViewSchedule))
             {
                 throw new InvalidOperationException(Properties.Resources.EmptySchedule);
             }

--- a/src/Libraries/RevitNodes/Elements/SketchPlane.cs
+++ b/src/Libraries/RevitNodes/Elements/SketchPlane.cs
@@ -107,8 +107,7 @@ namespace Revit.Elements
 
             TransactionManager.Instance.TransactionTaskDone();
 
-            ElementBinder.SetElementForTrace(this.InternalElement);
-
+            ElementBinder.SetElementForTrace(InternalElementId, InternalUniqueId);
         }
 
         #endregion
@@ -191,7 +190,7 @@ namespace Revit.Elements
             {
                 throw new ArgumentNullException("plane");
             }
-            
+
             return new SketchPlane(plane.ToPlane());
         }
 

--- a/src/Libraries/RevitNodes/Elements/Space.cs
+++ b/src/Libraries/RevitNodes/Elements/Space.cs
@@ -1,13 +1,9 @@
-﻿using Autodesk.DesignScript.Runtime;
+﻿using System.Collections.Generic;
+using Autodesk.DesignScript.Runtime;
 using Autodesk.Revit.DB;
 using Revit.GeometryConversion;
 using RevitServices.Persistence;
 using RevitServices.Transactions;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Revit.Elements
 {
@@ -111,7 +107,7 @@ namespace Revit.Elements
             // Commit transaction
             TransactionManager.Instance.TransactionTaskDone();
 
-            ElementBinder.SetElementForTrace(this.InternalElement);
+            ElementBinder.SetElementForTrace(InternalElementId, InternalUniqueId);
         }
 
         #endregion

--- a/src/Libraries/RevitNodes/Elements/StucturalFraming.cs
+++ b/src/Libraries/RevitNodes/Elements/StucturalFraming.cs
@@ -31,8 +31,8 @@ namespace Revit.Elements
         /// <summary>
         /// Internal constructor - creates a single StructuralFraming instance
         /// </summary>
-        internal StructuralFraming(Autodesk.Revit.DB.Curve curve, Autodesk.Revit.DB.XYZ upVector, 
-            Autodesk.Revit.DB.Level level, Autodesk.Revit.DB.Structure.StructuralType structuralType, 
+        internal StructuralFraming(Autodesk.Revit.DB.Curve curve, Autodesk.Revit.DB.XYZ upVector,
+            Autodesk.Revit.DB.Level level, Autodesk.Revit.DB.Structure.StructuralType structuralType,
             Autodesk.Revit.DB.FamilySymbol symbol)
         {
             SafeInit(() => InitStructuralFraming(curve, upVector, level, structuralType, symbol));
@@ -46,7 +46,7 @@ namespace Revit.Elements
         {
             SafeInit(() => InitStructuralFraming(curve, level, structuralType, symbol));
         }
-        
+
         #endregion
 
         #region Helpers for private constructors
@@ -112,7 +112,7 @@ namespace Revit.Elements
 
             TransactionManager.Instance.TransactionTaskDone();
 
-            ElementBinder.SetElementForTrace(this.InternalElement);
+            ElementBinder.SetElementForTrace(InternalElementId, InternalUniqueId);
         }
 
         /// <summary>
@@ -173,7 +173,7 @@ namespace Revit.Elements
 
             TransactionManager.Instance.TransactionTaskDone();
 
-            ElementBinder.SetElementForTrace(this.InternalElement);
+            ElementBinder.SetElementForTrace(InternalElementId, InternalUniqueId);
         }
 
         #endregion
@@ -262,7 +262,7 @@ namespace Revit.Elements
         /// </search>
         [Obsolete("Use Element.ElementType instead.")]
         public new FamilyType Type
-        {    
+        {
             // NOTE: Because AbstractFamilyInstance is not visible in the library
             //       we redefine this method on FamilyInstance
             get { return base.Type; }
@@ -294,7 +294,7 @@ namespace Revit.Elements
         /// <param name="structuralFramingType">The structural framing type representing the structural type</param>
         /// <returns></returns>
         [Obsolete("Use StructuralFraming.BeamByCurve, StructuralFraming.BraceByCurve, or StructuralFraming.ColumnByCurve instead.")]
-        public static StructuralFraming ByCurveLevelUpVectorAndType(Autodesk.DesignScript.Geometry.Curve curve, Level level, 
+        public static StructuralFraming ByCurveLevelUpVectorAndType(Autodesk.DesignScript.Geometry.Curve curve, Level level,
             Autodesk.DesignScript.Geometry.Vector upVector, StructuralType structuralType, FamilyType structuralFramingType)
         {
             if (curve == null)
@@ -315,7 +315,7 @@ namespace Revit.Elements
             if (structuralFramingType == null)
             {
                 throw new ArgumentNullException("structuralFramingType");
-            }            
+            }
 
             return new StructuralFraming(curve.ToRevitType(), upVector.ToXyz(), level.InternalLevel,
                 structuralType.ToRevitType(), structuralFramingType.InternalFamilySymbol);

--- a/src/Libraries/RevitNodes/Elements/Tag.cs
+++ b/src/Libraries/RevitNodes/Elements/Tag.cs
@@ -1,11 +1,11 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Linq;
 using Autodesk.DesignScript.Runtime;
 using Autodesk.Revit.DB;
 using Revit.GeometryConversion;
 using RevitServices.Persistence;
 using RevitServices.Transactions;
-using System.Collections.Generic;
-using System.Linq;
 
 namespace Revit.Elements
 {
@@ -113,7 +113,7 @@ namespace Revit.Elements
             var hostElementIds = new List<ElementId>();
             var linkedElementIds = new List<ElementId>();
 
-            if(tagElem != null)
+            if (tagElem != null)
             {
                 hostElementIds.AddRange(tagElem.GetTaggedElementIds().Select(x => x.HostElementId));
                 linkedElementIds.AddRange(tagElem.GetTaggedElementIds().Select(x => x.LinkedElementId));
@@ -150,7 +150,8 @@ namespace Revit.Elements
             InternalSetElement(tagElem);
 
             TransactionManager.Instance.TransactionTaskDone();
-            ElementBinder.SetElementForTrace(this.InternalElement);
+
+            ElementBinder.SetElementForTrace(InternalElementId, InternalUniqueId);
         }
 
         #endregion
@@ -255,7 +256,7 @@ namespace Revit.Elements
         /// <search>
         /// tagelement,annotate,documentation
         /// </search>
-        public static Tag ByElement(Revit.Elements.Views.View view, Element element, bool horizontal, bool addLeader, string horizontalAlignment, string verticalAlignment, [DefaultArgument("Autodesk.DesignScript.Geometry.Vector.ByCoordinates(0,0,0)")]Autodesk.DesignScript.Geometry.Vector offset, bool isOffset = true)
+        public static Tag ByElement(Revit.Elements.Views.View view, Element element, bool horizontal, bool addLeader, string horizontalAlignment, string verticalAlignment, [DefaultArgument("Autodesk.DesignScript.Geometry.Vector.ByCoordinates(0,0,0)")] Autodesk.DesignScript.Geometry.Vector offset, bool isOffset = true)
         {
             Autodesk.Revit.DB.HorizontalAlignmentStyle horizontalAlignmentStyle = HorizontalAlignmentStyle.Center;
             if (!Enum.TryParse<Autodesk.Revit.DB.HorizontalAlignmentStyle>(horizontalAlignment, out horizontalAlignmentStyle))
@@ -324,7 +325,7 @@ namespace Revit.Elements
         /// <search>
         /// tagelement,annotate,documentation,tagoffset,movetag
         /// </search>
-        public static Tag ByElementAndOffset(Revit.Elements.Views.View view, Element element, [DefaultArgument("Autodesk.DesignScript.Geometry.Vector.ByCoordinates(0,0,0)")]Autodesk.DesignScript.Geometry.Vector offset, string horizontalAlignment = "Center", string verticalAlignment = "Middle", bool horizontal = true, bool addLeader = false)
+        public static Tag ByElementAndOffset(Revit.Elements.Views.View view, Element element, [DefaultArgument("Autodesk.DesignScript.Geometry.Vector.ByCoordinates(0,0,0)")] Autodesk.DesignScript.Geometry.Vector offset, string horizontalAlignment = "Center", string verticalAlignment = "Middle", bool horizontal = true, bool addLeader = false)
         {
             Autodesk.Revit.DB.HorizontalAlignmentStyle horizontalAlignmentStyle = HorizontalAlignmentStyle.Center;
             if (!Enum.TryParse<Autodesk.Revit.DB.HorizontalAlignmentStyle>(horizontalAlignment, out horizontalAlignmentStyle))
@@ -339,7 +340,7 @@ namespace Revit.Elements
             }
 
             Autodesk.Revit.DB.View revitView = (Autodesk.Revit.DB.View)view.InternalElement;
-            
+
             // Tagging elements by element category
             Autodesk.Revit.DB.TagMode tagMode = TagMode.TM_ADDBY_CATEGORY;
 
@@ -373,7 +374,8 @@ namespace Revit.Elements
         /// </summary>
         public Revit.Elements.Element TaggedElement
         {
-            get {
+            get
+            {
                 var eles = this.InternalTextNote.GetTaggedLocalElements();
                 if (eles.Count == 1)
                     return (Revit.Elements.Element)ElementWrapper.Wrap(eles.First(), true);
@@ -407,7 +409,7 @@ namespace Revit.Elements
             TransactionManager.Instance.EnsureInTransaction(document);
 
             tagElem.TagHeadPosition = point;
-            
+
             double rotation = (tagElem.TagOrientation == TagOrientation.Horizontal) ? 0 : 90;
             InternalSetType(tagElem.TagText, tagElem.TagHeadPosition, rotation);
 
@@ -469,7 +471,7 @@ namespace Revit.Elements
             get
             {
                 if (this.InternalTextNote.HasLeader)
-                    if(this.InternalTextNote.LeaderEndCondition.Equals(LeaderEndCondition.Free))
+                    if (this.InternalTextNote.LeaderEndCondition.Equals(LeaderEndCondition.Free))
                     {
                         var refs = InternalTextNote.GetTaggedReferences();
                         if (refs.Count == 1)
@@ -477,7 +479,7 @@ namespace Revit.Elements
                         else
                             throw new Exception(Properties.Resources.GetTaggedReferences);
                     }
-                        
+
                 return null;
             }
         }
@@ -545,7 +547,7 @@ namespace Revit.Elements
         internal static Tag FromExisting(Autodesk.Revit.DB.IndependentTag instance, bool isRevitOwned)
         {
             return new Tag(instance)
-            { 
+            {
                 IsRevitOwned = isRevitOwned
             };
         }

--- a/src/Libraries/RevitNodes/Elements/TextNote.cs
+++ b/src/Libraries/RevitNodes/Elements/TextNote.cs
@@ -174,7 +174,7 @@ namespace Revit.Elements
                     }
                 }
 
-                
+
             }
 
             RVT.TextNoteType type = (RVT.TextNoteType)document.GetElement(typeId);
@@ -182,8 +182,8 @@ namespace Revit.Elements
             InternalSetElement(element);
 
             TransactionManager.Instance.TransactionTaskDone();
-            ElementBinder.SetElementForTrace(this.InternalElement);
 
+            ElementBinder.SetElementForTrace(InternalElementId, InternalUniqueId);
         }
 
         #endregion
@@ -201,7 +201,7 @@ namespace Revit.Elements
         /// <param name="rotation">Rotation in degrees</param>
         /// <param name="type">Revit TextNote Type</param>
         /// <returns></returns>
-        public static TextNote ByLocation(Revit.Elements.Views.View view, Autodesk.DesignScript.Geometry.Point location, string text, string alignment, [DefaultArgument("Revit.Elements.TextNoteType.Default()")]TextNoteType type, bool keepRotatedTextReadable = true, double rotation = 0)
+        public static TextNote ByLocation(Revit.Elements.Views.View view, Autodesk.DesignScript.Geometry.Point location, string text, string alignment, [DefaultArgument("Revit.Elements.TextNoteType.Default()")] TextNoteType type, bool keepRotatedTextReadable = true, double rotation = 0)
         {
             RVT.HorizontalTextAlignment horizontalTextAlignmentStyle = HorizontalTextAlignment.Center;
             if (!Enum.TryParse<RVT.HorizontalTextAlignment>(alignment, out horizontalTextAlignmentStyle))
@@ -320,7 +320,7 @@ namespace Revit.Elements
         internal static TextNote FromExisting(Autodesk.Revit.DB.TextNote instance, bool isRevitOwned)
         {
             return new TextNote(instance)
-            { 
+            {
                 IsRevitOwned = isRevitOwned
             };
         }

--- a/src/Libraries/RevitNodes/Elements/Topography.cs
+++ b/src/Libraries/RevitNodes/Elements/Topography.cs
@@ -96,11 +96,11 @@ namespace Revit.Elements
 
             if (oldSurf != null)
             {
-                ElementBinder.CleanupAndSetElementForTrace(Document, this.InternalElement);
+                ElementBinder.CleanupAndSetElementForTrace(Document, InternalElementId, InternalUniqueId);
             }
             else
             {
-                ElementBinder.SetElementForTrace(this.InternalElement);
+                ElementBinder.SetElementForTrace(InternalElementId, InternalUniqueId);
             }
 
             // necessary so the points in the topography are valid

--- a/src/Libraries/RevitNodes/Elements/Toposolid.cs
+++ b/src/Libraries/RevitNodes/Elements/Toposolid.cs
@@ -97,7 +97,7 @@ namespace Revit.Elements
 
             TransactionManager.Instance.TransactionTaskDone();
 
-            ElementBinder.CleanupAndSetElementForTrace(Document, InternalToposolid);
+            ElementBinder.CleanupAndSetElementForTrace(Document, InternalElementId, InternalUniqueId);
         }
 
         /// <summary>
@@ -113,7 +113,7 @@ namespace Revit.Elements
 
             TransactionManager.Instance.TransactionTaskDone();
 
-            ElementBinder.CleanupAndSetElementForTrace(Document, InternalToposolid);
+            ElementBinder.CleanupAndSetElementForTrace(Document, InternalElementId, InternalUniqueId);
         }
 
         /// <summary>
@@ -129,7 +129,7 @@ namespace Revit.Elements
 
             TransactionManager.Instance.TransactionTaskDone();
 
-            ElementBinder.CleanupAndSetElementForTrace(Document, InternalToposolid);
+            ElementBinder.CleanupAndSetElementForTrace(Document, InternalElementId, InternalUniqueId);
         }
 
         #endregion
@@ -281,7 +281,7 @@ namespace Revit.Elements
         /// <returns></returns>
         /// <exception cref="System.ArgumentNullException"></exception>
         /// <exception cref="System.ArgumentException"></exception>
-        public static Toposolid ByOutlineTypeAndLevel(PolyCurve outline,  ToposolidType toposolidType, Level level)
+        public static Toposolid ByOutlineTypeAndLevel(PolyCurve outline, ToposolidType toposolidType, Level level)
         {
             if (outline == null)
             {
@@ -349,7 +349,7 @@ namespace Revit.Elements
             DocumentManager.Regenerate();
             return toposolid;
         }
-        
+
         #endregion
 
         #region Internal static constructors

--- a/src/Libraries/RevitNodes/Elements/Viewport.cs
+++ b/src/Libraries/RevitNodes/Elements/Viewport.cs
@@ -1,8 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Autodesk.DesignScript.Geometry;
 using Autodesk.Revit.DB;
 using Revit.Elements.Views;
@@ -96,7 +93,7 @@ namespace Revit.Elements
                 if (!Autodesk.Revit.DB.Viewport.CanAddViewToSheet(Document, sheetId, viewId))
                 {
                     viewportElement.SetBoxCenter(viewLocation);
-                }                    
+                }
                 else
                 {
                     viewportElement = Autodesk.Revit.DB.Viewport.Create(Document, sheetId, viewId, viewLocation);
@@ -107,7 +104,7 @@ namespace Revit.Elements
 
             TransactionManager.Instance.TransactionTaskDone();
 
-            ElementBinder.CleanupAndSetElementForTrace(Document, this.InternalElement);
+            ElementBinder.CleanupAndSetElementForTrace(Document, InternalElementId, InternalUniqueId);
         }
 
         #endregion
@@ -148,7 +145,7 @@ namespace Revit.Elements
             get
             {
                 var view = (Autodesk.Revit.DB.View)Document.GetElement(InternalViewport.ViewId);
-                return (Revit.Elements.Views.View) ElementWrapper.ToDSType(view, true);
+                return (Revit.Elements.Views.View)ElementWrapper.ToDSType(view, true);
             }
         }
 
@@ -265,7 +262,7 @@ namespace Revit.Elements
             {
                 throw new ArgumentNullException("sheet");
             }
-            if (view == null) 
+            if (view == null)
             {
                 throw new ArgumentNullException("view");
             }

--- a/src/Libraries/RevitNodes/Elements/Views/AreaPlanView.cs
+++ b/src/Libraries/RevitNodes/Elements/Views/AreaPlanView.cs
@@ -55,7 +55,7 @@ namespace Revit.Elements.Views
 
             TransactionManager.Instance.TransactionTaskDone();
 
-            ElementBinder.CleanupAndSetElementForTrace(Document, InternalElement);
+            ElementBinder.CleanupAndSetElementForTrace(Document, InternalElementId, InternalUniqueId);
         }
 
         #endregion

--- a/src/Libraries/RevitNodes/Elements/Views/AxonometricView.cs
+++ b/src/Libraries/RevitNodes/Elements/Views/AxonometricView.cs
@@ -85,7 +85,7 @@ namespace Revit.Elements.Views
 
             TransactionManager.Instance.TransactionTaskDone();
 
-            ElementBinder.SetElementForTrace(this.InternalElement);
+            ElementBinder.SetElementForTrace(InternalElementId, InternalUniqueId);
         }
 
         /// <summary>
@@ -117,7 +117,7 @@ namespace Revit.Elements.Views
 
             TransactionManager.Instance.TransactionTaskDone();
 
-            ElementBinder.SetElementForTrace(this.InternalElement);
+            ElementBinder.SetElementForTrace(InternalElementId, InternalUniqueId);
         }
 
         #endregion
@@ -150,7 +150,7 @@ namespace Revit.Elements.Views
         /// <returns>An AxonometricView object.</returns>
         public static AxonometricView ByEyePointAndTarget(
             Autodesk.DesignScript.Geometry.Point eyePoint,
-            Autodesk.DesignScript.Geometry.Point target, 
+            Autodesk.DesignScript.Geometry.Point target,
             string name = DEFAULT_VIEW_NAME)
         {
             if (eyePoint == null)
@@ -181,10 +181,10 @@ namespace Revit.Elements.Views
         /// crop box around it.</param>
         /// <returns>An AxonometricView object.</returns>
         public static AxonometricView ByEyePointTargetAndElement(
-            Autodesk.DesignScript.Geometry.Point eyePoint, 
+            Autodesk.DesignScript.Geometry.Point eyePoint,
             Autodesk.DesignScript.Geometry.Point target,
-            string name = DEFAULT_VIEW_NAME, 
-            Element element = null, 
+            string name = DEFAULT_VIEW_NAME,
+            Element element = null,
             bool isolateElement = false)
         {
             if (eyePoint == null)
@@ -216,7 +216,7 @@ namespace Revit.Elements.Views
                     element.InternalElement,
                     isolateElement);
             }
-            
+
         }
 
         /// <summary>
@@ -230,10 +230,10 @@ namespace Revit.Elements.Views
         /// bounding box will be isolated in the current view by creating a minimum size
         /// crop box around it.</param>
         /// <returns>An AxonometricView object.</returns>
-        public static AxonometricView ByEyePointTargetAndBoundingBox(Autodesk.DesignScript.Geometry.Point eyePoint, 
-            Autodesk.DesignScript.Geometry.Point target, 
-            Autodesk.DesignScript.Geometry.BoundingBox boundingBox, 
-            string name = DEFAULT_VIEW_NAME, 
+        public static AxonometricView ByEyePointTargetAndBoundingBox(Autodesk.DesignScript.Geometry.Point eyePoint,
+            Autodesk.DesignScript.Geometry.Point target,
+            Autodesk.DesignScript.Geometry.BoundingBox boundingBox,
+            string name = DEFAULT_VIEW_NAME,
             bool isolateElement = false)
         {
             if (boundingBox == null)

--- a/src/Libraries/RevitNodes/Elements/Views/CeilingPlanView.cs
+++ b/src/Libraries/RevitNodes/Elements/Views/CeilingPlanView.cs
@@ -56,7 +56,7 @@ namespace Revit.Elements.Views
 
             TransactionManager.Instance.TransactionTaskDone();
 
-            ElementBinder.CleanupAndSetElementForTrace(Document, this.InternalElement);
+            ElementBinder.CleanupAndSetElementForTrace(Document, InternalElementId, InternalUniqueId);
         }
 
         #endregion

--- a/src/Libraries/RevitNodes/Elements/Views/DraftingView.cs
+++ b/src/Libraries/RevitNodes/Elements/Views/DraftingView.cs
@@ -46,7 +46,7 @@ namespace Revit.Elements.Views
         {
             SafeInit(() => InitDraftingView(view), true);
         }
-      
+
         /// <summary>
         /// Private constructor
         /// </summary>
@@ -88,7 +88,7 @@ namespace Revit.Elements.Views
 
             TransactionManager.Instance.TransactionTaskDone();
 
-            ElementBinder.CleanupAndSetElementForTrace(Document, this.InternalElement);
+            ElementBinder.CleanupAndSetElementForTrace(Document, InternalElementId, InternalUniqueId);
         }
 
         #endregion
@@ -116,14 +116,14 @@ namespace Revit.Elements.Views
         /// </summary>
         /// <param name="name">Name of the view</param>
         /// <returns>The view</returns>
-        public static DraftingView ByName( string name )
+        public static DraftingView ByName(string name)
         {
             if (name == null)
             {
                 throw new ArgumentNullException("name");
             }
 
-            return new DraftingView( name );
+            return new DraftingView(name);
         }
         #endregion
 

--- a/src/Libraries/RevitNodes/Elements/Views/FloorPlanView.cs
+++ b/src/Libraries/RevitNodes/Elements/Views/FloorPlanView.cs
@@ -55,7 +55,7 @@ namespace Revit.Elements.Views
 
             TransactionManager.Instance.TransactionTaskDone();
 
-            ElementBinder.CleanupAndSetElementForTrace(Document, InternalElement);
+            ElementBinder.CleanupAndSetElementForTrace(Document, InternalElementId, InternalUniqueId);
         }
 
         #endregion
@@ -74,7 +74,7 @@ namespace Revit.Elements.Views
                 throw new ArgumentNullException("level");
             }
 
-            return new FloorPlanView( level.InternalLevel );
+            return new FloorPlanView(level.InternalLevel);
         }
 
         #endregion
@@ -87,7 +87,7 @@ namespace Revit.Elements.Views
         /// <param name="plan"></param>
         /// <param name="isRevitOwned"></param>
         /// <returns></returns>
-        internal static FloorPlanView FromExisting( Autodesk.Revit.DB.ViewPlan plan, bool isRevitOwned )
+        internal static FloorPlanView FromExisting(Autodesk.Revit.DB.ViewPlan plan, bool isRevitOwned)
         {
             if (plan == null)
             {

--- a/src/Libraries/RevitNodes/Elements/Views/PerspectiveView.cs
+++ b/src/Libraries/RevitNodes/Elements/Views/PerspectiveView.cs
@@ -99,7 +99,7 @@ namespace Revit.Elements.Views
 
             TransactionManager.Instance.TransactionTaskDone();
 
-            ElementBinder.SetElementForTrace(this.InternalElement);
+            ElementBinder.SetElementForTrace(InternalElementId, InternalUniqueId);
         }
 
         /// <summary>
@@ -145,7 +145,7 @@ namespace Revit.Elements.Views
 
             TransactionManager.Instance.TransactionTaskDone();
 
-            ElementBinder.SetElementForTrace(this.InternalElement);
+            ElementBinder.SetElementForTrace(InternalElementId, InternalUniqueId);
         }
 
         #endregion
@@ -273,7 +273,7 @@ namespace Revit.Elements.Views
         /// <param name="view"></param>
         /// <param name="isRevitOwned"></param>
         /// <returns></returns>
-        internal static PerspectiveView FromExisting( Autodesk.Revit.DB.View3D view, bool isRevitOwned )
+        internal static PerspectiveView FromExisting(Autodesk.Revit.DB.View3D view, bool isRevitOwned)
         {
             return new PerspectiveView(view)
             {

--- a/src/Libraries/RevitNodes/Elements/Views/ScheduleView.cs
+++ b/src/Libraries/RevitNodes/Elements/Views/ScheduleView.cs
@@ -95,13 +95,13 @@ namespace Revit.Elements.Views
             TransactionManager.Instance.EnsureInTransaction(doc);
 
             // Get existing view if possible
-            var vs = ElementBinder.GetElementFromTrace<Autodesk.Revit.DB.ViewSchedule>(doc) ?? 
+            var vs = ElementBinder.GetElementFromTrace<Autodesk.Revit.DB.ViewSchedule>(doc) ??
                 CreateViewSchedule(category, name, type);
 
             InternalSetScheduleView(vs);
 
             TransactionManager.Instance.TransactionTaskDone();
-            ElementBinder.CleanupAndSetElementForTrace(doc, InternalElement);
+            ElementBinder.CleanupAndSetElementForTrace(Document, InternalElementId, InternalUniqueId);
         }
 
         /// <summary>
@@ -121,7 +121,7 @@ namespace Revit.Elements.Views
             InternalSetScheduleView(vs);
 
             TransactionManager.Instance.TransactionTaskDone();
-            ElementBinder.CleanupAndSetElementForTrace(doc, InternalElement);
+            ElementBinder.CleanupAndSetElementForTrace(Document, InternalElementId, InternalUniqueId);
         }
 
         #endregion

--- a/src/Libraries/RevitNodes/Elements/Views/SectionView.cs
+++ b/src/Libraries/RevitNodes/Elements/Views/SectionView.cs
@@ -53,7 +53,7 @@ namespace Revit.Elements.Views
         /// <summary>
         /// Private constructor
         /// </summary>
-        private SectionView( BoundingBoxXYZ bbox )
+        private SectionView(BoundingBoxXYZ bbox)
         {
             SafeInit(() => InitSectionView(bbox));
         }
@@ -83,7 +83,7 @@ namespace Revit.Elements.Views
 
             TransactionManager.Instance.TransactionTaskDone();
 
-            ElementBinder.CleanupAndSetElementForTrace(Document, this.InternalElement);
+            ElementBinder.CleanupAndSetElementForTrace(Document, InternalElementId, InternalUniqueId);
         }
 
         #endregion
@@ -118,7 +118,7 @@ namespace Revit.Elements.Views
                 throw new Exception("There is no three dimensional view family in the document");
             }
 
-            var viewSection = ViewSection.CreateSection( Document, viewFam.Id, bbox);
+            var viewSection = ViewSection.CreateSection(Document, viewFam.Id, bbox);
 
             TransactionManager.Instance.TransactionTaskDone();
 

--- a/src/Libraries/RevitNodes/Elements/Views/StructuralPlanView.cs
+++ b/src/Libraries/RevitNodes/Elements/Views/StructuralPlanView.cs
@@ -56,7 +56,7 @@ namespace Revit.Elements.Views
 
             TransactionManager.Instance.TransactionTaskDone();
 
-            ElementBinder.CleanupAndSetElementForTrace(Document, this.InternalElement);
+            ElementBinder.CleanupAndSetElementForTrace(Document, InternalElementId, InternalUniqueId);
         }
 
         #endregion

--- a/src/Libraries/RevitNodes/Elements/Views/View.cs
+++ b/src/Libraries/RevitNodes/Elements/Views/View.cs
@@ -2,10 +2,10 @@
 using System.Collections.Generic;
 using System.Drawing;
 using System.IO;
-using Autodesk.Revit.DB;
-using RevitServices.Persistence;
 using System.Linq;
+using Autodesk.Revit.DB;
 using Revit.GeometryConversion;
+using RevitServices.Persistence;
 
 namespace Revit.Elements.Views
 {
@@ -206,7 +206,7 @@ namespace Revit.Elements.Views
             viewDiscipline = (ViewDiscipline)Enum.Parse(typeof(ViewDiscipline), discipline);
 
             RevitServices.Transactions.TransactionManager.Instance.EnsureInTransaction(Application.Document.Current.InternalDocument);
-            if(InternalView.CanModifyViewDiscipline())
+            if (InternalView.CanModifyViewDiscipline())
             {
                 var param = InternalView.get_Parameter(BuiltInParameter.VIEW_DISCIPLINE);
                 param.Set((int)viewDiscipline);
@@ -215,7 +215,7 @@ namespace Revit.Elements.Views
             {
                 throw new Exception(String.Format(Properties.Resources.CantModifyInView, "ViewDiscipline"));
             }
-            
+
             RevitServices.Transactions.TransactionManager.Instance.TransactionTaskDone();
 
             return this;
@@ -250,7 +250,7 @@ namespace Revit.Elements.Views
             displaystyle = (DisplayStyle)Enum.Parse(typeof(DisplayStyle), displayStyle);
 
             RevitServices.Transactions.TransactionManager.Instance.EnsureInTransaction(Application.Document.Current.InternalDocument);
-            if(InternalView.CanModifyDisplayStyle())
+            if (InternalView.CanModifyDisplayStyle())
                 InternalView.DisplayStyle = displaystyle;
             else
             {
@@ -542,7 +542,7 @@ namespace Revit.Elements.Views
         /// </summary>
         /// <param name="scale">View scale is the ration of true model size to paper size.</param>
         /// <returns name="view">View</returns>
-        public Revit.Elements.Views.View SetScale(int scale=100)
+        public Revit.Elements.Views.View SetScale(int scale = 100)
         {
             if (Autodesk.Revit.DB.View.IsValidViewScale(scale))
             {
@@ -583,7 +583,7 @@ namespace Revit.Elements.Views
         /// <returns></returns>
         public Boolean CanViewBeDuplicated(string viewDuplicateOption = "Duplicate")
         {
-            ViewDuplicateOption Option = (ViewDuplicateOption)Enum.Parse(typeof(ViewDuplicateOption),viewDuplicateOption);
+            ViewDuplicateOption Option = (ViewDuplicateOption)Enum.Parse(typeof(ViewDuplicateOption), viewDuplicateOption);
 
             return InternalView.CanViewBeDuplicated(Option);
         }
@@ -616,7 +616,7 @@ namespace Revit.Elements.Views
                 string newViewName = "";
                 if (!String.IsNullOrEmpty(prefix) || !String.IsNullOrEmpty(suffix))
                 {
-                    newViewName = prefix + view.Name + suffix;                    
+                    newViewName = prefix + view.Name + suffix;
                 }
                 Autodesk.Revit.UI.UIDocument uIDocument = new Autodesk.Revit.UI.UIDocument(Document);
                 var openedViews = uIDocument.GetOpenUIViews().ToList();
@@ -630,8 +630,8 @@ namespace Revit.Elements.Views
                     else
                         count--;
                 }
-                
-                if (count == 0) 
+
+                if (count == 0)
                 {
                     if (!CheckUniqueViewName(newViewName))
                         throw new ArgumentException(String.Format(Properties.Resources.ViewNameExists, newViewName));
@@ -664,10 +664,10 @@ namespace Revit.Elements.Views
                                     throw new InvalidOperationException(string.Format(Properties.Resources.CantCloseLastOpenView, viewElement.ToString()));
                             }
                         }
-                    }                    
-                }                
+                    }
+                }
 
-                ElementBinder.CleanupAndSetElementForTrace(Document, newView.InternalElement);
+                ElementBinder.CleanupAndSetElementForTrace(Document, newView.InternalElementId, newView.InternalUniqueId);
 
                 RevitServices.Transactions.TransactionManager.Instance.TransactionTaskDone();
             }
@@ -675,12 +675,12 @@ namespace Revit.Elements.Views
             {
                 //if (e is Autodesk.Revit.Exceptions.InvalidOperationException)
                 //    throw e;
-                if (newView != null) 
+                if (newView != null)
                 {
                     newView.Dispose();
                 }
                 throw e;
-            }            
+            }
 
             return newView;
         }
@@ -853,7 +853,7 @@ namespace Revit.Elements.Views
         #endregion
 
         #region PartsVisibility
-        
+
         /// <summary>
         /// The visibility setting for parts in this view. 
         /// </summary>

--- a/src/Libraries/RevitNodes/Elements/Wall.cs
+++ b/src/Libraries/RevitNodes/Elements/Wall.cs
@@ -102,7 +102,7 @@ namespace Revit.Elements
                     (wallLocation.Curve is Autodesk.Revit.DB.Arc == curve is Autodesk.Revit.DB.Arc) ||
                     (wallLocation.Curve is Autodesk.Revit.DB.Ellipse == curve is Autodesk.Revit.DB.Ellipse))
                 {
-                    if(!CurveUtils.CurvesAreSimilar(wallLocation.Curve, curve))
+                    if (!CurveUtils.CurvesAreSimilar(wallLocation.Curve, curve))
                         wallLocation.Curve = curve;
 
                     Autodesk.Revit.DB.Parameter baseLevelParameter =
@@ -127,8 +127,7 @@ namespace Revit.Elements
 
             TransactionManager.Instance.TransactionTaskDone();
 
-            // delete the element stored in trace and add this new one
-            ElementBinder.CleanupAndSetElementForTrace(Document, InternalWall);
+            ElementBinder.CleanupAndSetElementForTrace(Document, InternalElementId, InternalUniqueId);
         }
 
         #endregion

--- a/src/Libraries/RevitNodes/Filter/ParameterFilterElement.cs
+++ b/src/Libraries/RevitNodes/Filter/ParameterFilterElement.cs
@@ -59,7 +59,7 @@ namespace Revit.Filter
         /// <param name="elem"></param>
         private ParameterFilterElement(Autodesk.Revit.DB.ParameterFilterElement elem)
         {
-            SafeInit(() => InitElement(elem),true);
+            SafeInit(() => InitElement(elem), true);
         }
 
         /// <summary>
@@ -97,21 +97,21 @@ namespace Revit.Filter
             Autodesk.Revit.DB.Document document = DocumentManager.Instance.CurrentDBDocument;
             TransactionManager.Instance.EnsureInTransaction(document);
             var elemFilters = new List<ElementFilter>();
-            foreach(var rule in rules)
+            foreach (var rule in rules)
             {
-               var elemParamFilter = new ElementParameterFilter(rule);
-               elemFilters.Add(elemParamFilter);
+                var elemParamFilter = new ElementParameterFilter(rule);
+                elemFilters.Add(elemParamFilter);
             }
             Autodesk.Revit.DB.ElementFilter eleFilter = new LogicalOrFilter(elemFilters);
 
             var elem = ElementBinder.GetElementFromTrace<Autodesk.Revit.DB.ParameterFilterElement>(document);
-         
+
 
             if (elem == null)
             {
-               // ParameterFilterElement..::..Create Method (Document, String, ICollection<ElementId>, IList<FilterRule>) is deprecated in Revit 2019 and will be removed in the next version of Revit. 
-               //We suggest you instead use a Create method that takes an ElementFilter as input.
-               elem = Autodesk.Revit.DB.ParameterFilterElement.Create(document, name, ids.ToList(), eleFilter);
+                // ParameterFilterElement..::..Create Method (Document, String, ICollection<ElementId>, IList<FilterRule>) is deprecated in Revit 2019 and will be removed in the next version of Revit. 
+                //We suggest you instead use a Create method that takes an ElementFilter as input.
+                elem = Autodesk.Revit.DB.ParameterFilterElement.Create(document, name, ids.ToList(), eleFilter);
             }
             else
             {
@@ -125,7 +125,8 @@ namespace Revit.Filter
             InternalSetElement(elem);
 
             TransactionManager.Instance.TransactionTaskDone();
-            ElementBinder.SetElementForTrace(this.InternalElement);
+
+            ElementBinder.SetElementForTrace(InternalElementId, InternalUniqueId);
         }
 
         #endregion
@@ -143,7 +144,7 @@ namespace Revit.Filter
         {
             List<Autodesk.Revit.DB.FilterRule> ruleSet = new List<Autodesk.Revit.DB.FilterRule>();
             foreach (FilterRule rule in rules)
-            { 
+            {
                 ruleSet.Add(rule.InternalFilterRule);
             }
 
@@ -169,7 +170,7 @@ namespace Revit.Filter
         internal static ParameterFilterElement FromExisting(Autodesk.Revit.DB.ParameterFilterElement instance, bool isRevitOwned)
         {
             return new ParameterFilterElement(instance)
-            { 
+            {
                 IsRevitOwned = isRevitOwned
             };
         }


### PR DESCRIPTION
### List of Affected Nodes/Modules

All nodes that wrap or create Revit elements

### Current Performance
Every time an element is wrapped, we store its id and unique id. Then the native element is passed to the element binder and the id and unique id properties are fetched again. It didn't make sense to me to pay the cost of fetching those twice after already referencing them (plus also allocating the memory):

![devenv_yxJHtQs9CG](https://github.com/user-attachments/assets/e510bed3-7dfd-4785-8278-4c512c811fac)

### Proposed Performance
We should not pass the native element but the already extracted id and unique ids:

![8tJoXZEI27](https://github.com/user-attachments/assets/68e8a991-bf48-496f-b89c-81cab288bb07)

The cost is mostly from fetching the unique id/ Unfortunately, the performance benefit did not quite pan out the way I expected it to (should have reduced the get_UniqueId total cpu time by at least half)

### Dynamo Tuneup Comparison
With a very basic graph that fetches 25k elements and creates 10k instances the performance gain is negligible and we go from 4.7 seconds on average down to 4.6:

![Revit_LovGNJkCAB-base](https://github.com/user-attachments/assets/76d75965-09bb-4ea9-983b-a09d02e53d2c)

![Revit_4Qptcy6dOL-change](https://github.com/user-attachments/assets/4f7ce7ac-6b4d-4cb9-8aab-474b20f88ca5)

Overall I am not entirely sure if this change is worth it due to the large code change.

### Checklist

- [x] There are no public function signature changes
- [x] Any public code that is no longer in use is tagged as obsolete and preserved.
- [x] The code changes have been documented
- [x] The overall behavior does not change
