### PR TITLE
Dead-End: Very slow exception handling

### DIFF
--- a/src/Libraries/RevitNodes/Elements/Category.cs
+++ b/src/Libraries/RevitNodes/Elements/Category.cs
@@ -1,10 +1,9 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Linq;
-
 using Autodesk.DesignScript.Runtime;
 using Autodesk.Revit.DB;
 using RevitServices.Persistence;
-using System.Collections.Generic;
 
 namespace Revit.Elements
 {
@@ -35,7 +34,7 @@ namespace Revit.Elements
             get
             {
                 var parent = internalCategory.Parent;
-                if(parent == null)
+                if (parent == null)
                 {
                     return internalCategory.Name;
                 }
@@ -103,14 +102,16 @@ namespace Revit.Elements
                 var document = DocumentManager.Instance.CurrentDBDocument;
                 BuiltInCategory categoryId = (BuiltInCategory)id;
                 Autodesk.Revit.DB.Category category = Autodesk.Revit.DB.Category.GetCategory(document, categoryId);
-                if(null == category)
-                    throw new ArgumentException(Properties.Resources.InvalidCategory);
+                if (null == category)
+                {
+                    return null;
+                }
 
                 return new Category(category);
             }
             catch
             {
-                throw new ArgumentException(Properties.Resources.InvalidCategory);
+                return null;
             }
         }
 
@@ -143,32 +144,32 @@ namespace Revit.Elements
         private static Autodesk.Revit.DB.Category GetCategory(String name)
         {
             Autodesk.Revit.DB.Category category = null;
-            
+
             var splits = name.Split('-');
 
             // search by ui name first, that can be "{parent name} - {name}" or only the "{name}"
             category = FindCategory((Autodesk.Revit.DB.Category cat) => { return name.Equals(new Revit.Elements.Category(cat).Name); });
-            if(category != null)
+            if (category != null)
             {
                 return category;
             }
             else if (splits.Count() > 1)
             {
                 var indexs = FindAllChars(name, '-');
-                foreach(var index in indexs)
+                foreach (var index in indexs)
                 {
                     var parentName = name.Substring(0, index).TrimEnd(' ');
                     var subName = name.Substring(index + 1).TrimStart(' ');
                     Autodesk.Revit.DB.Category parentCategory = FindCategory((Autodesk.Revit.DB.Category cat) => { return parentName.Equals(cat.Name); });
-                    if(parentCategory != null)
+                    if (parentCategory != null)
                     {
-                        if(parentCategory.SubCategories.Contains(subName))
+                        if (parentCategory.SubCategories.Contains(subName))
                         {
                             category = parentCategory.SubCategories.get_Item(subName);
                             break;
                         }
                     }
-                }                
+                }
             }
             else
             {
@@ -176,7 +177,7 @@ namespace Revit.Elements
                 // Use category enum name with or without OST_ prefix
                 var fullName = name.Length > 3 && name.Substring(0, 4) == "OST_" ? name : "OST_" + name;
                 var names = Enum.GetNames(typeof(BuiltInCategory));
-                if(System.Array.Exists(names, entry => entry == fullName))
+                if (System.Array.Exists(names, entry => entry == fullName))
                 {
                     var builtInCat = (BuiltInCategory)Enum.Parse(typeof(BuiltInCategory), fullName);
                     category = Autodesk.Revit.DB.Category.GetCategory(DocumentManager.Instance.CurrentDBDocument, builtInCat);
@@ -194,8 +195,8 @@ namespace Revit.Elements
             int index = -1;
             for (int i = 0; i < splits.Count() - 1; i++)
             {
-               index = index + splits[i].Length + 1;
-               CharIndex.Add(index);
+                index = index + splits[i].Length + 1;
+                CharIndex.Add(index);
             }
 
             return CharIndex;
@@ -219,7 +220,7 @@ namespace Revit.Elements
                     continue;
                 }
 
-                if(tempCategory != null && pred(tempCategory))
+                if (tempCategory != null && pred(tempCategory))
                 {
                     return tempCategory;
                 }


### PR DESCRIPTION
building as release and running in that mode, we completely get rid of the exception cost:
![image](https://github.com/user-attachments/assets/9e61322d-bbe9-488c-844b-adcd738c2101)


<details>
  <summary>superseded details</summary>

I am trying to figure out why running a very basic python node that just returns all categories runs incredibly slow:

![WMywTslvNU](https://github.com/user-attachments/assets/68d45b78-162f-4678-a1bc-44156ef52203)

This is the content of the node - it is extremely simple and only calls the Dynamo category wrapper about a thousand times:
![DynamoSandbox_PfvX9uHUnJ](https://github.com/user-attachments/assets/1d0b0782-e4f8-41b4-9467-9232577bb742)

Initially I incorrectly assumed that I can just add a "bad category ids list" and improve the performance on consecutive runs. That however made zero difference to the overall performance (before vs after):

![devenv_a5L0MtpViu](https://github.com/user-attachments/assets/6cfa41c3-33a7-435c-8d0f-d0fc89ccfe9f)

![devenv_wDu3Snl4xG](https://github.com/user-attachments/assets/b58e1405-6be2-47a5-ae9e-33981f1e7304)

![devenv_K2waw3kmwF](https://github.com/user-attachments/assets/696b8348-cfe9-438f-b2fa-a5081cb355a4)

It still took over 13 seconds to run this single node. I then looked at the flame graph and realized that the extra 13 seconds of computing come purely from throwing the exceptions (look at the lines throwing the exceptions):

![devenv_Qd2rRxx88e](https://github.com/user-attachments/assets/6e966e09-f9ae-41f7-8aec-492288ee6fd2)

![devenv_L3yTRmfZkS](https://github.com/user-attachments/assets/451b98af-304a-4fd1-8111-38d704593cc1)

If we don't throw exceptions and just return nulls, that completely negates the slowdown:

![yfh6lYJWQ4](https://github.com/user-attachments/assets/27b984c6-a040-4395-a8a2-c3f9d0891699)

Now, clearly we don't want to do that, because it breaks the overall functionality. But what can we do to avoid the cost? I know that exceptions are slow but they should not be this slow. Is the problem in the underlying Dynamo core VM or is it somewhere else? Do you have any further observations on this?

</detail>