### PR TITLE
Storing parameter definitions

### DIFF
--- a/src/DynamoRevit/Models/RevitDynamoModel.cs
+++ b/src/DynamoRevit/Models/RevitDynamoModel.cs
@@ -18,7 +18,6 @@ using Dynamo.Logging;
 using Dynamo.Models;
 using Dynamo.PythonServices;
 using Dynamo.Scheduler;
-using Dynamo.Updates;
 using Dynamo.Utilities;
 using Greg;
 using Newtonsoft.Json;
@@ -200,7 +199,7 @@ namespace Dynamo.Applications.Models
 
         public new static RevitDynamoModel Start()
         {
-            return Start(new RevitStartConfiguration() { ProcessMode = TaskProcessMode.Asynchronous } );
+            return Start(new RevitStartConfiguration() { ProcessMode = TaskProcessMode.Asynchronous });
         }
 
         public new static RevitDynamoModel Start(IRevitStartConfiguration configuration)
@@ -288,7 +287,7 @@ namespace Dynamo.Applications.Models
 
                 //this is a list of all trace data for all nodes in the workspace of this orphan
                 var nodeTraceDataList = runtimeCore.RuntimeData.GetCallsitesForNodes(nodeGuids, runtimeCore.DSExecutable);
-               
+
                 //check each callsite's traceData against the orphans
                 foreach (var kvp in nodeTraceDataList)
                 {
@@ -300,7 +299,7 @@ namespace Dynamo.Applications.Models
 
                         var currentStringIds = currentMultipleSerializableIdObject.SelectMany(x => x.StringIDs).ToList();
                         //if the orphaned serializable exists in the currentTraceData as as subset in a MultiSerializableID
-                        toRemove.AddRange(orphanMultipleSerializableIdObjects.Where(x => currentMultipleSerializableIdObject.Any(y => x.isSubset(y))).SelectMany(x=>x.StringIDs).ToList());
+                        toRemove.AddRange(orphanMultipleSerializableIdObjects.Where(x => currentMultipleSerializableIdObject.Any(y => x.isSubset(y))).SelectMany(x => x.StringIDs).ToList());
                         //Or if one of the callsites traceData is subset in an orphan
                         toRemove.AddRange(currentStringIds.Intersect(orphanStringIDs).ToList());
                         //then remove it from the orphanList so we do not delete it later
@@ -318,7 +317,7 @@ namespace Dynamo.Applications.Models
 
             if (!orphanedIds.Any())
                 return;
-            
+
             if (IsTestMode)
             {
                 DeleteOrphanedElements(orphanedIds, Logger);
@@ -337,12 +336,12 @@ namespace Dynamo.Applications.Models
         private List<MultipleSerializableId> GetAnyMultipleSerializableIDsFromListOfTraceData(IEnumerable<string> currentSerializables)
         {
             var anyMultipleSerializableId = new List<MultipleSerializableId>();
-            if (currentSerializables == null) 
+            if (currentSerializables == null)
                 return anyMultipleSerializableId;
 
-            foreach(var currentSerializable in currentSerializables)
+            foreach (var currentSerializable in currentSerializables)
             {
-                if(currentSerializable == null) continue;
+                if (currentSerializable == null) continue;
 
                 MultipleSerializableId multi = null;
                 try
@@ -361,7 +360,7 @@ namespace Dynamo.Applications.Models
             return anyMultipleSerializableId;
         }
 
-        private List<string> GetAnyStringIDsFromSerializableIDsPressentInOrhpanDictionary(Dictionary<Guid,List<string>> orphanedSerializables)
+        private List<string> GetAnyStringIDsFromSerializableIDsPressentInOrhpanDictionary(Dictionary<Guid, List<string>> orphanedSerializables)
         {
             var allStringIDs = new List<string>();
 
@@ -450,7 +449,7 @@ namespace Dynamo.Applications.Models
                     engine.EvaluationStarted += OnPythonEvalStart;
                     engine.EvaluationFinished += OnPythonEvalFinished;
                 }
-                catch(FileNotFoundException ex)
+                catch (FileNotFoundException ex)
                 {
                     Logger.Log(ex);
                 }
@@ -730,6 +729,9 @@ namespace Dynamo.Applications.Models
             // finally close the transaction!
             TransactionManager.Instance.ForceCloseTransaction();
 
+            // clear the parameters cache
+            Revit.Elements.Element.ClearParametersCache();
+
             base.OnEvaluationCompleted(sender, e);
         }
 
@@ -771,7 +773,7 @@ namespace Dynamo.Applications.Models
         protected override void PostShutdownCore(bool shutdownHost)
         {
             base.PostShutdownCore(shutdownHost);
-            
+
             // Always reset current UI document on shutdown
             DocumentManager.Instance.CurrentUIDocument = null;
         }
@@ -837,13 +839,13 @@ namespace Dynamo.Applications.Models
                         string.Format("Active view is now {0}", newView.Name));
                 }
 
-                if(raiseRevitContextAvailableEvent)
+                if (raiseRevitContextAvailableEvent)
                 {
                     // Pick up current state
                     bool currentState = true;
                     foreach (HomeWorkspaceModel ws in Workspaces.OfType<HomeWorkspaceModel>())
                     {
-                        if(!ws.RunSettings.RunEnabled)
+                        if (!ws.RunSettings.RunEnabled)
                         {
                             currentState = false;
                             break;

--- a/src/Libraries/RevitNodes/Elements/Element.cs
+++ b/src/Libraries/RevitNodes/Elements/Element.cs
@@ -414,7 +414,7 @@ namespace Revit.Elements
         /// </summary>
         /// <param name="parameterName">The name of the parameter.</param>
         /// <returns></returns>
-        private Autodesk.Revit.DB.Parameter GetParameterByName(Autodesk.Revit.DB.Element e, string parameterName)
+        private Autodesk.Revit.DB.Parameter GetParameterByName(string parameterName)
         {
             //
             // Parameter names are not unique on a given element. There are several valid cases where 
@@ -443,7 +443,7 @@ namespace Revit.Elements
             {
                 foreach (var d in knownDefinitions)
                 {
-                    var p = e.get_Parameter(d);
+                    var p = InternalElement.get_Parameter(d);
                     if (p != null)
                     {
                         return p;

--- a/src/Libraries/RevitNodes/Elements/Element.cs
+++ b/src/Libraries/RevitNodes/Elements/Element.cs
@@ -451,10 +451,7 @@ namespace Revit.Elements
                 }
             }
 
-            var allParams =
-            InternalElement.Parameters.Cast<Autodesk.Revit.DB.Parameter>()
-                .Where(x => string.CompareOrdinal(x.Definition.Name, parameterName) == 0)
-                .OrderBy(x => x.Id.Value);
+            var allParams = InternalElement.GetParameters(parameterName).OrderBy(x => x.Id.Value);
 
             var param = allParams.FirstOrDefault(x => x.IsReadOnly == false) ?? allParams.FirstOrDefault();
 

--- a/src/Libraries/RevitNodes/Elements/Element.cs
+++ b/src/Libraries/RevitNodes/Elements/Element.cs
@@ -458,7 +458,7 @@ namespace Revit.Elements
 
             var param = allParams.FirstOrDefault(x => x.IsReadOnly == false) ?? allParams.FirstOrDefault();
 
-            if (knownDefinitions == null)
+            if (param != null && knownDefinitions == null)
             {
                 knownDefinitions = new List<Definition> { param.Definition };
                 ParameterDefinitionsCache[parameterName] = knownDefinitions;


### PR DESCRIPTION
### List of Affected Nodes/Modules

Element.GetParameterByName
Element.SetParameterByName

### Current Performance
This PR is related to #1, as it affects a similar scenario - finding parameters by their name is expensive. In the previous PR we skip the step getting the parameter definitions but we were still paying the cost of querying an element's parameters by name. In this PR we explore the option of instead caching the results of that query and fetching the element's parameters by the definition. As discussed previously, the current performance is less than ideal:

![devenv_6jbBVbFpeL](https://github.com/user-attachments/assets/3d1a256d-f156-4b45-be32-e447441c3cd4)

### Proposed Performance
If we have a simple lookup dictionary that stores a list of all found definitions that match that name, it is likely that we can reuse the expected definition. The cache will be used only for the duration of the execution and cleared in case the user modifies the project parameters. By keeping the same parameter priority logic (parameter with latest id is chosen first), we should ensure the original intent is preserved.

![devenv_MPRpf4ZunM](https://github.com/user-attachments/assets/874776c3-19b1-468f-9ba1-6aa3d3f5886f)

### Dynamo Tuneup Comparison
Collecting ~55k elements and fetching a single parameter value we drop form around 9 seconds[1] on average down to about 1.5 seconds. Keep in mind that this is an ideal scenario, because all of the elements we collected are from a single category and share the same definition. A mixed collection of parameter names and elements that don't necessarily share the same definition will perform worse.

![xkH3wxPejm](https://github.com/user-attachments/assets/72c79985-e712-4481-aca4-9ca83b020898)

![5U97ja5f6A](https://github.com/user-attachments/assets/fd2cedcf-0892-43bc-b19e-eaabcde59a45)


### Checklist

- [x] There are no public function signature changes
- [x] Any public code that is no longer in use is tagged as obsolete and preserved.
- [x] The code changes have been documented
- [x] The overall behavior does not change

[1] The graph was simplified compared to the version in #1